### PR TITLE
Add NodeForm grammar and schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ NFL graphs are validated via JSON Schema and can compile to diverse runtimes (WA
 
 This syntax keeps the language minimal while remaining expressive across domains.
 
+
+## Specification
+
+See the `spec/` directory for language details:
+
+* `grammar.ebnf` – draft grammar for NFL.
+* `nfl.schema.json` – JSON Schema describing `pack`, `node`, `edge`, `trait`, and `impl`.
+
+Graphs should validate against `nfl.schema.json` to ensure structural correctness.

--- a/spec/grammar.ebnf
+++ b/spec/grammar.ebnf
@@ -1,0 +1,23 @@
+(* NodeForm Language - Draft EBNF *)
+
+nfl            = { statement } ;
+
+statement      = pack | node | edge ;
+
+pack           = "pack" identifier ;
+node           = ("fn" | "node") identifier "(" [ parameters ] ")" "{" node_body "}" ;
+edge           = "edge" identifier "->" identifier [ edge_body ] ;
+
+parameters     = parameter { "," parameter } ;
+parameter      = identifier ":" identifier ;
+
+node_body      = { attribute } ;
+edge_body      = { attribute } ;
+
+attribute      = trait | impl ;
+trait          = "traits" "=" "[" identifier { "," identifier } "]" ;
+impl           = "impl" "=" json_object ;
+
+identifier     = ? letters, digits or '_' ? ;
+json_object    = ? JSON object ? ;
+

--- a/spec/nfl.schema.json
+++ b/spec/nfl.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "NodeForm graph",
+  "type": "object",
+  "required": ["pack"],
+  "properties": {
+    "pack": { "type": "string" },
+    "nodes": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/node" }
+    },
+    "edges": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/edge" }
+    }
+  },
+  "definitions": {
+    "node": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "type": "string" },
+        "trait": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "impl": { "type": "object" }
+      }
+    },
+    "edge": {
+      "type": "object",
+      "required": ["from", "to"],
+      "properties": {
+        "from": { "type": "string" },
+        "to": { "type": "string" },
+        "trait": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "impl": { "type": "object" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add draft EBNF grammar for NodeForm
- add JSON schema capturing pack, node, edge, trait and impl
- document schema location in README

## Testing
- `git status --short`