### PR TITLE
add OpenPermit and OpenTax examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,17 @@ NFL graphs are validated via JSON Schema and can compile to diverse runtimes (WA
 * `impl` – provide the implementation
 
 This syntax keeps the language minimal while remaining expressive across domains.
+
+## Examples
+
+The `examples` directory provides small NFL graphs:
+
+* `simple.json` – minimal nodes and an edge
+* `open_permit.json` – basic Open Permit workflow
+* `open_tax.json` – property tax relationship
+
+Validate an example with the CLI:
+
+```bash
+python3 cli/nfl_cli.py examples/open_permit.json
+```

--- a/examples/open_permit.json
+++ b/examples/open_permit.json
@@ -1,0 +1,10 @@
+{
+  "pack": "open.permit",
+  "nodes": [
+    {"name": "address", "type": "Address"},
+    {"name": "permit", "type": "BuildingPermit"}
+  ],
+  "edges": [
+    {"from": "address", "to": "permit"}
+  ]
+}

--- a/examples/open_tax.json
+++ b/examples/open_tax.json
@@ -1,0 +1,10 @@
+{
+  "pack": "open.tax",
+  "nodes": [
+    {"name": "parcel", "type": "Property"},
+    {"name": "tax_bill", "type": "TaxBill"}
+  ],
+  "edges": [
+    {"from": "parcel", "to": "tax_bill"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add sample `open_permit.json` and `open_tax.json`
- list new examples in README

## Testing
- `python3 cli/nfl_cli.py examples/open_tax.json`
- `python3 cli/nfl_cli.py examples/open_permit.json`
