### PR TITLE
Add OpenAPI export CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ NFL graphs are validated via JSON Schema and can compile to diverse runtimes (WA
 * `impl` – provide the implementation
 
 This syntax keeps the language minimal while remaining expressive across domains.
+
+## CLI Usage
+
+The repository provides a small command line tool for validating NFL graphs and
+exporting them as an OpenAPI specification:
+
+```bash
+$ python -m cli.nfl_cli examples/simple.json --export-openapi graph.openapi.json
+```
+
+The generated `graph.openapi.json` contains a basic OpenAPI 3.0 document with
+`/nodes` and `/edges` endpoints that describe the graph structure.

--- a/cli/nfl_cli.py
+++ b/cli/nfl_cli.py
@@ -6,6 +6,8 @@ import json
 import os
 import sys
 
+from . import nfl_to_openapi
+
 
 def load_json(path: str):
     """Load a JSON file from *path*."""
@@ -81,11 +83,22 @@ def main(argv=None) -> int:
         default=os.path.join(os.path.dirname(__file__), "..", "schema", "nfl.schema.json"),
         help="Path to the NFL JSON Schema (default: %(default)s)",
     )
+    parser.add_argument(
+        "--export-openapi",
+        metavar="FILE",
+        help="Write an OpenAPI specification to FILE",
+    )
 
     args = parser.parse_args(argv)
 
-    if validate_file(args.file, args.schema):
+    valid = validate_file(args.file, args.schema)
+    if valid:
         print(f"{args.file} is valid.")
+        if args.export_openapi:
+            spec = nfl_to_openapi.convert_file(args.file)
+            with open(args.export_openapi, "w", encoding="utf-8") as fh:
+                json.dump(spec, fh, indent=2)
+            print(f"OpenAPI written to {args.export_openapi}")
         return 0
     return 1
 

--- a/cli/nfl_to_openapi.py
+++ b/cli/nfl_to_openapi.py
@@ -1,0 +1,90 @@
+"""Convert NFL JSON graphs to a minimal OpenAPI specification."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+def convert(nfl: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a dictionary representing an OpenAPI spec for *nfl*."""
+    nodes = nfl.get("nodes", [])
+    edges = nfl.get("edges", [])
+
+    spec = {
+        "openapi": "3.0.0",
+        "info": {
+            "title": f"NFL Graph - {nfl.get('pack', '')}",
+            "version": "1.0.0",
+        },
+        "paths": {
+            "/nodes": {
+                "get": {
+                    "summary": "List nodes",
+                    "responses": {
+                        "200": {
+                            "description": "List of nodes",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Node"},
+                                    },
+                                    "example": nodes,
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+            "/edges": {
+                "get": {
+                    "summary": "List edges",
+                    "responses": {
+                        "200": {
+                            "description": "List of edges",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": {"$ref": "#/components/schemas/Edge"},
+                                    },
+                                    "example": edges,
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+        },
+        "components": {
+            "schemas": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "type": {"type": "string"},
+                    },
+                },
+                "Edge": {
+                    "type": "object",
+                    "properties": {
+                        "from": {"type": "string"},
+                        "to": {"type": "string"},
+                    },
+                },
+            }
+        },
+    }
+
+    return spec
+
+
+def convert_file(path: str) -> Dict[str, Any]:
+    """Load the NFL file at *path* and convert it to OpenAPI."""
+    with open(path, "r", encoding="utf-8") as fh:
+        nfl = json.load(fh)
+    return convert(nfl)
+
+
+__all__ = ["convert", "convert_file"]


### PR DESCRIPTION
## Summary
- add module to convert NFL JSON to a simple OpenAPI spec
- expose `--export-openapi` option in CLI
- document the new capability in the README

## Testing
- `python3 -m py_compile cli/*.py`
- `python3 -m cli.nfl_cli examples/simple.json --export-openapi openapi.json`