### PR TITLE
Add trait and impl properties to schema

### DIFF
--- a/schema/nfl.schema.json
+++ b/schema/nfl.schema.json
@@ -10,7 +10,12 @@
         "type": "object",
         "properties": {
           "name": { "type": "string" },
-          "type": { "type": "string" }
+          "type": { "type": "string" },
+          "trait": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "impl": { "type": "object" }
         },
         "required": ["name", "type"],
         "additionalProperties": true
@@ -22,7 +27,12 @@
         "type": "object",
         "properties": {
           "from": { "type": "string" },
-          "to": { "type": "string" }
+          "to": { "type": "string" },
+          "trait": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "impl": { "type": "object" }
         },
         "required": ["from", "to"],
         "additionalProperties": true


### PR DESCRIPTION
## Summary
- expand `schema/nfl.schema.json` to document optional `trait` and `impl`
  properties on nodes and edges

## Testing
- `python3 -m cli.nfl_cli examples/agent_interaction.json --schema schema/nfl.schema.json`
- `python3 -m cli.nfl_cli examples/open_permit.json --schema schema/nfl.schema.json`
- `python3 -m cli.nfl_cli examples/open_tax.json --schema schema/nfl.schema.json`
- `python3 -m cli.nfl_cli examples/simple.json --schema schema/nfl.schema.json`
