### PR TITLE
Add JSON Schema validation and tests

### DIFF
--- a/cli/nfl_cli.py
+++ b/cli/nfl_cli.py
@@ -5,6 +5,57 @@ import argparse
 import json
 import os
 import sys
+from typing import Any
+
+try:
+    from jsonschema import validate as jsonschema_validate
+    from jsonschema.exceptions import ValidationError
+    _HAS_JSONSCHEMA = True
+except Exception:  # pragma: no cover - dependency missing
+    _HAS_JSONSCHEMA = False
+
+    class ValidationError(Exception):
+        """Fallback ValidationError when jsonschema is unavailable."""
+
+
+def _fallback_validate(instance: Any, schema: Any) -> None:
+    """A very small JSON Schema validator supporting the NFL schema."""
+
+    def _error(msg: str) -> None:
+        raise ValidationError(msg)
+
+    if not isinstance(instance, dict):
+        _error("NFL file must be a JSON object")
+
+    if schema.get("type") != "object":
+        _error("Schema root must be an object")
+
+    required = schema.get("required", [])
+    for key in required:
+        if key not in instance:
+            _error(f"Missing required property: {key}")
+
+    properties = schema.get("properties", {})
+    for key, value in instance.items():
+        subschema = properties.get(key)
+        if not subschema:
+            continue
+        if subschema.get("type") == "string" and not isinstance(value, str):
+            _error(f"'{key}' must be a string")
+        if subschema.get("type") == "array":
+            if not isinstance(value, list):
+                _error(f"'{key}' must be a list")
+            item_schema = subschema.get("items", {})
+            for item in value:
+                if item_schema.get("type") == "object" and not isinstance(item, dict):
+                    _error(f"items of '{key}' must be objects")
+                if isinstance(item, dict):
+                    req = item_schema.get("required", [])
+                    for r in req:
+                        if r not in item:
+                            _error(f"Missing required property in {key}: {r}")
+
+    return None
 
 from . import nfl_to_openapi
 
@@ -19,8 +70,8 @@ def validate_file(nfl_path: str, schema_path: str) -> bool:
     """Validate *nfl_path* against *schema_path*.
 
     Returns ``True`` if the file is valid, otherwise ``False``.
-    This implementation performs a minimal structural validation matching the
-    provided schema.
+    Uses :mod:`jsonschema` when available and falls back to a very small
+    validator that covers the shipped schema.
     """
     try:
         nfl = load_json(nfl_path)
@@ -34,38 +85,14 @@ def validate_file(nfl_path: str, schema_path: str) -> bool:
         print(f"Failed to load schema '{schema_path}': {exc}")
         return False
 
-    # minimal manual validation since jsonschema is unavailable
-    if not isinstance(nfl, dict):
-        print("NFL file must be a JSON object")
+    try:
+        if _HAS_JSONSCHEMA:
+            jsonschema_validate(instance=nfl, schema=schema)
+        else:
+            _fallback_validate(nfl, schema)
+    except ValidationError as exc:
+        print(f"Validation error: {exc}")
         return False
-
-    if "pack" not in nfl or not isinstance(nfl["pack"], str):
-        print("'pack' property missing or not a string")
-        return False
-
-    if "nodes" in nfl:
-        if not isinstance(nfl["nodes"], list):
-            print("'nodes' must be a list")
-            return False
-        for node in nfl["nodes"]:
-            if not isinstance(node, dict):
-                print("each node must be an object")
-                return False
-            if "name" not in node or "type" not in node:
-                print("node entries require 'name' and 'type'")
-                return False
-
-    if "edges" in nfl:
-        if not isinstance(nfl["edges"], list):
-            print("'edges' must be a list")
-            return False
-        for edge in nfl["edges"]:
-            if not isinstance(edge, dict):
-                print("each edge must be an object")
-                return False
-            if "from" not in edge or "to" not in edge:
-                print("edge entries require 'from' and 'to'")
-                return False
 
     return True
 

--- a/tests/test_validate_file.py
+++ b/tests/test_validate_file.py
@@ -1,0 +1,27 @@
+import json
+import tempfile
+from pathlib import Path
+import unittest
+
+import cli.nfl_cli as cli
+
+EXAMPLES = Path(__file__).resolve().parents[1] / "examples"
+SCHEMA = Path(__file__).resolve().parents[1] / "schema" / "nfl.schema.json"
+
+
+class TestValidateFile(unittest.TestCase):
+    def test_valid_examples(self):
+        for path in EXAMPLES.glob("*.json"):
+            self.assertTrue(cli.validate_file(str(path), str(SCHEMA)), f"{path} should be valid")
+
+    def test_missing_pack(self):
+        data = json.loads((EXAMPLES / "simple.json").read_text())
+        data.pop("pack", None)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_file = Path(tmpdir) / "invalid.json"
+            tmp_file.write_text(json.dumps(data))
+            self.assertFalse(cli.validate_file(str(tmp_file), str(SCHEMA)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve validator by using a JSON Schema checker with a small fallback implementation
- validate graph documents using the schema
- add unit tests for valid and invalid NFL documents

## Testing
- `python -m unittest discover -v tests`