### PR TITLE
Add semantic export utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This syntax keeps the language minimal while remaining expressive across domains
 ## CLI Usage
 
 The repository provides a small command line tool for validating NFL graphs and
-exporting them as an OpenAPI specification:
+exporting them as an OpenAPI specification or other semantic formats:
 
 ```bash
 $ python -m cli.nfl_cli examples/simple.json --export-openapi graph.openapi.json
@@ -48,6 +48,18 @@ $ python -m cli.nfl_cli examples/simple.json --export-openapi graph.openapi.json
 
 The generated `graph.openapi.json` contains a basic OpenAPI 3.0 document with
 `/nodes` and `/edges` endpoints that describe the graph structure.
+
+To export a JSON-LD representation or an OWL/Turtle file use the new
+`--export-jsonld` and `--export-owl` options. Additional helpers can produce
+GeoJSON and a very small IFC text export:
+
+```bash
+$ python -m cli.nfl_cli examples/simple.json \
+    --export-jsonld graph.jsonld \
+    --export-owl graph.ttl \
+    --export-geojson graph.geojson \
+    --export-ifc graph.ifc
+```
 
 ## Pilot Platform Mappings
 

--- a/cli/nfl_cli.py
+++ b/cli/nfl_cli.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 from . import nfl_to_openapi
+from . import nfl_to_semantics
 
 
 def load_json(path: str):
@@ -88,6 +89,26 @@ def main(argv=None) -> int:
         metavar="FILE",
         help="Write an OpenAPI specification to FILE",
     )
+    parser.add_argument(
+        "--export-jsonld",
+        metavar="FILE",
+        help="Write a JSON-LD graph to FILE",
+    )
+    parser.add_argument(
+        "--export-owl",
+        metavar="FILE",
+        help="Write an OWL/Turtle representation to FILE",
+    )
+    parser.add_argument(
+        "--export-geojson",
+        metavar="FILE",
+        help="Write a GeoJSON file to FILE",
+    )
+    parser.add_argument(
+        "--export-ifc",
+        metavar="FILE",
+        help="Write an IFC text representation to FILE",
+    )
 
     args = parser.parse_args(argv)
 
@@ -99,6 +120,24 @@ def main(argv=None) -> int:
             with open(args.export_openapi, "w", encoding="utf-8") as fh:
                 json.dump(spec, fh, indent=2)
             print(f"OpenAPI written to {args.export_openapi}")
+        if any([args.export_jsonld, args.export_owl, args.export_geojson, args.export_ifc]):
+            converted = nfl_to_semantics.convert_file(args.file)
+            if args.export_jsonld:
+                with open(args.export_jsonld, "w", encoding="utf-8") as fh:
+                    json.dump(converted["jsonld"], fh, indent=2)
+                print(f"JSON-LD written to {args.export_jsonld}")
+            if args.export_owl:
+                with open(args.export_owl, "w", encoding="utf-8") as fh:
+                    fh.write(converted["owl"])
+                print(f"OWL written to {args.export_owl}")
+            if args.export_geojson:
+                with open(args.export_geojson, "w", encoding="utf-8") as fh:
+                    json.dump(converted["geojson"], fh, indent=2)
+                print(f"GeoJSON written to {args.export_geojson}")
+            if args.export_ifc:
+                with open(args.export_ifc, "w", encoding="utf-8") as fh:
+                    fh.write(converted["ifc"])
+                print(f"IFC written to {args.export_ifc}")
         return 0
     return 1
 

--- a/cli/nfl_to_semantics.py
+++ b/cli/nfl_to_semantics.py
@@ -1,0 +1,103 @@
+"""Conversions from NFL graphs to semantic web formats."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+
+def convert_to_jsonld(nfl: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a JSON-LD representation of *nfl*."""
+    context = {
+        "name": "http://schema.org/name",
+        "type": "http://schema.org/additionalType",
+        "from": {"@id": "http://schema.org/from", "@type": "@id"},
+        "to": {"@id": "http://schema.org/to", "@type": "@id"},
+        "Node": "http://schema.org/Thing",
+        "Edge": "http://schema.org/ActionRelationship",
+    }
+
+    graph: List[Dict[str, Any]] = []
+
+    for node in nfl.get("nodes", []):
+        graph.append({
+            "@id": node.get("name"),
+            "@type": "Node",
+            "name": node.get("name"),
+            "type": node.get("type"),
+        })
+
+    for edge in nfl.get("edges", []):
+        graph.append({
+            "@type": "Edge",
+            "from": edge.get("from"),
+            "to": edge.get("to"),
+        })
+
+    return {"@context": context, "@graph": graph}
+
+
+def convert_to_owl(nfl: Dict[str, Any]) -> str:
+    """Return a very small OWL/Turtle representation of *nfl*."""
+    lines: List[str] = [
+        "@prefix : <http://example.org/nfl#> .",
+        "@prefix owl: <http://www.w3.org/2002/07/owl#> .",
+        "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .",
+        "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .",
+        "",
+        ":Ontology a owl:Ontology .",
+    ]
+
+    for node in nfl.get("nodes", []):
+        lines.append(f":{node.get('name')} a owl:NamedIndividual ;")
+        lines.append(f"    :type \"{node.get('type')}\" .")
+
+    for edge in nfl.get("edges", []):
+        lines.append(f":{edge.get('from')} :connectedTo :{edge.get('to')} .")
+
+    return "\n".join(lines)
+
+
+def convert_to_geojson(nfl: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a GeoJSON FeatureCollection if nodes have ``lat`` and ``lon``."""
+    features: List[Dict[str, Any]] = []
+    for node in nfl.get("nodes", []):
+        if "lat" in node and "lon" in node:
+            features.append({
+                "type": "Feature",
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [node["lon"], node["lat"]],
+                },
+                "properties": {k: v for k, v in node.items() if k not in {"lat", "lon"}},
+            })
+    return {"type": "FeatureCollection", "features": features}
+
+
+def convert_to_ifc(nfl: Dict[str, Any]) -> str:
+    """Return a placeholder IFC representation of *nfl*."""
+    lines = ["// IFC export is domain specific; placeholder only"]
+    for node in nfl.get("nodes", []):
+        lines.append(f"IFCENTITY({node.get('name')})")
+    return "\n".join(lines)
+
+
+def convert_file(path: str) -> Dict[str, Any]:
+    """Load an NFL JSON file and return semantic conversions."""
+    with open(path, "r", encoding="utf-8") as fh:
+        nfl = json.load(fh)
+    return {
+        "jsonld": convert_to_jsonld(nfl),
+        "owl": convert_to_owl(nfl),
+        "geojson": convert_to_geojson(nfl),
+        "ifc": convert_to_ifc(nfl),
+    }
+
+
+__all__ = [
+    "convert_to_jsonld",
+    "convert_to_owl",
+    "convert_to_geojson",
+    "convert_to_ifc",
+    "convert_file",
+]


### PR DESCRIPTION
## Summary
- add semantic export helpers for JSON-LD, OWL, GeoJSON, and IFC
- extend CLI to support new export options
- document the new command line flags

## Testing
- `python3 -m py_compile cli/*.py`
- `python3 -m cli.nfl_cli examples/simple.json --export-openapi test.openapi.json --export-jsonld test.jsonld --export-owl test.ttl --export-geojson test.geojson --export-ifc test.ifc`
