### PR TITLE
Add packaging with pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ NFL graphs are validated via JSON Schema and can compile to diverse runtimes (WA
 * `trait` – qualify behavior
 * `impl` – provide the implementation
 
+## Installation
+
+Install the CLI in editable mode:
+
+```bash
+$ pip install -e .
+```
+
+After installation, use the `nfl-cli` command to validate graphs:
+
+```bash
+$ nfl-cli examples/simple.json --export-openapi graph.openapi.json
+```
+
 This syntax keeps the language minimal while remaining expressive across domains.
 
 ## CLI Usage
@@ -43,7 +57,7 @@ The repository provides a small command line tool for validating NFL graphs and
 exporting them as an OpenAPI specification:
 
 ```bash
-$ python -m cli.nfl_cli examples/simple.json --export-openapi graph.openapi.json
+$ nfl-cli examples/simple.json --export-openapi graph.openapi.json
 ```
 
 The generated `graph.openapi.json` contains a basic OpenAPI 3.0 document with

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -1,0 +1,2 @@
+"""CLI utilities for the NodeForm Language."""
+__all__ = ["nfl_cli", "nfl_to_openapi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "nfl"
+version = "0.1.0"
+description = "NodeForm Language tools"
+authors = [{ name = "builtbycorelot" }]
+license = { file = "LICENSE" }
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "jsonschema"
+]
+
+[project.scripts]
+nfl-cli = "cli.nfl_cli:main"
+
+[tool.setuptools.packages.find]
+include = ["cli", "schema"]

--- a/schema/__init__.py
+++ b/schema/__init__.py
@@ -1,0 +1,2 @@
+"""Reference JSON Schemas for NFL."""
+__all__ = []

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="nfl",
+    version="0.1.0",
+    description="NodeForm Language tools",
+    author="builtbycorelot",
+    license="MIT",
+    packages=find_packages(include=["cli", "schema"]),
+    package_data={"schema": ["*.json"]},
+    include_package_data=True,
+    python_requires=">=3.8",
+    install_requires=["jsonschema"],
+    entry_points={"console_scripts": ["nfl-cli=cli.nfl_cli:main"]},
+)


### PR DESCRIPTION
## Summary
- add `pyproject.toml` and `setup.py` for packaging
- include empty `__init__` files so `cli` and `schema` are packages
- document editable install and CLI invocation in the README

## Testing
- `pip install -e .` *(fails: could not fetch build dependencies)*
- `python -m cli.nfl_cli examples/simple.json`