### PR TITLE
Add browser-based NFL viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,10 @@ concepts into a unified model with nodes such as `Party`, `Task`,
 `@platform` sections that map its fields to specific SaaS providers,
 demonstrating how the same semantics can synchronize data across Smartsheet,
 Intuit QuickBooks Online, and HubSpot.
+
+## Web Viewer
+
+A minimal HTML/JavaScript viewer is provided under the `docs/` directory so the
+examples can be explored in a browser. It uses D3.js to render nodes and edges.
+To try it locally, open `docs/index.html` in a web browser or enable GitHub
+Pages on the repository and navigate to the published site.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>NFL Graph Viewer</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 1em; }
+    #graph { width: 100%; height: 80vh; border: 1px solid #ccc; }
+    #controls { margin-bottom: 1em; }
+  </style>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+</head>
+<body>
+  <h1>NFL Graph Viewer</h1>
+  <div id="controls">
+    <input type="file" id="fileInput" accept="application/json">
+    <button id="loadExample">Load Example</button>
+  </div>
+  <svg id="graph"></svg>
+  <script>
+    const width = document.getElementById('graph').clientWidth;
+    const height = document.getElementById('graph').clientHeight;
+    const svg = d3.select('#graph')
+      .attr('width', width)
+      .attr('height', height);
+
+    document.getElementById('fileInput').addEventListener('change', function(e) {
+      const file = e.target.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = evt => renderGraph(JSON.parse(evt.target.result));
+        reader.readAsText(file);
+      }
+    });
+
+    document.getElementById('loadExample').addEventListener('click', () => {
+      fetch('simple.json').then(r => r.json()).then(renderGraph);
+    });
+
+    function renderGraph(nfl) {
+      svg.selectAll('*').remove();
+      const nodes = (nfl.nodes || []).map(n => ({ id: n.name }));
+      const links = (nfl.edges || []).map(e => ({ source: e.from, target: e.to }));
+
+      const simulation = d3.forceSimulation(nodes)
+        .force('link', d3.forceLink(links).id(d => d.id).distance(100))
+        .force('charge', d3.forceManyBody().strength(-300))
+        .force('center', d3.forceCenter(width / 2, height / 2));
+
+      const link = svg.append('g')
+        .attr('stroke', '#999')
+        .attr('stroke-opacity', 0.6)
+        .selectAll('line')
+        .data(links)
+        .enter().append('line')
+        .attr('stroke-width', 2);
+
+      const node = svg.append('g')
+        .attr('stroke', '#fff')
+        .attr('stroke-width', 1.5)
+        .selectAll('circle')
+        .data(nodes)
+        .enter().append('circle')
+        .attr('r', 10)
+        .attr('fill', '#69b3a2')
+        .call(drag(simulation));
+
+      const label = svg.append('g')
+        .selectAll('text')
+        .data(nodes)
+        .enter().append('text')
+        .attr('dy', -15)
+        .attr('text-anchor', 'middle')
+        .text(d => d.id);
+
+      simulation.on('tick', () => {
+        link
+          .attr('x1', d => d.source.x)
+          .attr('y1', d => d.source.y)
+          .attr('x2', d => d.target.x)
+          .attr('y2', d => d.target.y);
+
+        node
+          .attr('cx', d => d.x)
+          .attr('cy', d => d.y);
+
+        label
+          .attr('x', d => d.x)
+          .attr('y', d => d.y);
+      });
+    }
+
+    function drag(simulation) {
+      function dragstarted(event, d) {
+        if (!event.active) simulation.alphaTarget(0.3).restart();
+        d.fx = d.x;
+        d.fy = d.y;
+      }
+
+      function dragged(event, d) {
+        d.fx = event.x;
+        d.fy = event.y;
+      }
+
+      function dragended(event, d) {
+        if (!event.active) simulation.alphaTarget(0);
+        d.fx = null;
+        d.fy = null;
+      }
+
+      return d3.drag()
+        .on('start', dragstarted)
+        .on('drag', dragged)
+        .on('end', dragended);
+    }
+  </script>
+</body>
+</html>

--- a/docs/simple.json
+++ b/docs/simple.json
@@ -1,0 +1,11 @@
+{
+  "pack": "meta.core",
+  "nodes": [
+    {"name": "x", "type": "ℝ"},
+    {"name": "y", "type": "ℝ"}
+  ],
+  "edges": [
+    {"from": "x", "to": "y"}
+  ]
+}
+


### PR DESCRIPTION
## Summary
- add `docs/` with an `index.html` page that visualizes NFL JSON graphs using D3.js
- include a copy of `simple.json` to load as an example
- document the new web viewer in README

## Testing
- `git status --short`