### PR TITLE
Add relation example with rel^n trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ $ python -m cli.nfl_cli examples/simple.json --export-openapi graph.openapi.json
 
 The generated `graph.openapi.json` contains a basic OpenAPI 3.0 document with
 `/nodes` and `/edges` endpoints that describe the graph structure.
+Additional examples can be found in `examples/open_permit.json`, `examples/open_tax.json`, and `examples/rel_n.json`.
 
 ## Pilot Platform Mappings
 

--- a/examples/rel_n.json
+++ b/examples/rel_n.json
@@ -1,0 +1,14 @@
+{
+  "pack": "meta.core",
+  "nodes": [
+    {"name": "quantitative", "type": "\u211d"},
+    {"name": "logical", "type": "Bool"},
+    {"name": "semantic", "type": "Text"},
+    {"name": "schematic", "type": "Diagram"}
+  ],
+  "edges": [
+    {"from": "quantitative", "to": "logical", "trait": ["rel^n"]},
+    {"from": "logical", "to": "semantic", "trait": ["rel^n"]},
+    {"from": "semantic", "to": "schematic", "trait": ["rel^n"]}
+  ]
+}


### PR DESCRIPTION
## Summary
- add new `rel_n.json` example illustrating edges with `rel^n`
- mention new example in README alongside other examples

## Testing
- `python3 -m cli.nfl_cli examples/rel_n.json`
- `for f in examples/*.json; do echo "Validating $f"; python3 -m cli.nfl_cli "$f"; done`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new example file illustrating a layered relationship model between different types of entities.
- **Documentation**
  - Updated the CLI Usage section in the documentation to reference additional example files for user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->