### PR TITLE
Fix pytest install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,12 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "jsonschema",
-    "pytest"
+    "jsonschema"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.1,<8"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- move pytest from mandatory project dependencies to optional test dependency

## Testing
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Moved `pytest` to an optional testing dependencies section, requiring version 7.1 or higher but less than 8. The main dependencies remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->