### PR TITLE
Add test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Pre-rendered outputs are located in the [`codecs/`](codecs/) folder. A lightweig
 
 Stub runtime packs are provided in [`packs/`](packs/) for future execution tests.
 
+## Development and Testing
+
+NFL requires **Python&nbsp;3.8 or higher**. Install the optional test dependencies and run the suite with:
+
+```bash
+pip install -e .[test]
+pytest
+```
+
 ## ContextMD
 
 See [`docs/context.md`](docs/context.md) for a high level summary and links to related documents.


### PR DESCRIPTION
## Summary
- document Python requirement and how to run tests

## Testing
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "Development and Testing" section to the README, specifying the minimum Python version required and providing instructions for installing test dependencies and running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->