### PR TITLE
Fix schema loading

### DIFF
--- a/cli/nfl_cli.py
+++ b/cli/nfl_cli.py
@@ -45,17 +45,9 @@ def validate_file(nfl_path: str, schema_path: str) -> bool:
         return False
 
     try:
-
         schema = load_json(schema_path)
-    except IOError as exc:
+    except (IOError, json.JSONDecodeError) as exc:
         print(exc)
-        return False
-    except json.JSONDecodeError as exc:
-        print(exc)
-=======
-        load_json(schema_path)
-    except Exception as exc:
-        print(f"Failed to load schema '{schema_path}': {exc}")
         return False
 
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,3 +27,10 @@ def test_convert_file_simple():
         {"from": "x", "to": "y"}
     ]
 
+
+def test_validate_file_schema_error(tmp_path, capsys):
+    missing = tmp_path / "missing.json"
+    assert not validate_file("examples/simple.json", str(missing))
+    captured = capsys.readouterr()
+    assert f"Failed to read '{missing}'" in captured.out
+


### PR DESCRIPTION
## Summary
- cleanup stray merge conflict lines in `nfl_cli`
- consolidate schema loading error handling
- add a unit test for schema loading failures

## Testing
- `pytest -q` *(fails: command not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify correct error handling when a schema file is missing during file validation.

- **Refactor**
  - Streamlined error handling for schema loading to reduce redundancy in exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->