### PR TITLE
Add benchmark harness with docker-compose

### DIFF
--- a/NFL-bench/README.md
+++ b/NFL-bench/README.md
@@ -1,0 +1,29 @@
+# NFL Bench Harness
+
+This directory provides a lightweight benchmarking harness for the NodeForm Language runtime.
+
+## Prerequisites
+
+* Docker and Docker Compose installed locally.
+
+## Running
+
+1. Start the services and run the default synthetic workload:
+
+```bash
+cd NFL-bench
+docker-compose up -d
+./runner.sh
+```
+
+2. Generate a custom workload (optional):
+
+```bash
+python workloads/generate_workload.py custom.json -n 100
+./runner.sh custom.json
+```
+
+3. After the run completes, open `dashboard.html` in a browser to view metrics.
+Results are written as CSV files under the `results/` directory.
+
+Use `docker-compose down` to stop and remove containers when finished.

--- a/NFL-bench/dashboard.html
+++ b/NFL-bench/dashboard.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>NFL Bench Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>NFL Bench Metrics</h1>
+  <canvas id="chart" width="600" height="400"></canvas>
+  <script>
+    fetch('results/metrics.csv')
+      .then(resp => resp.text())
+      .then(text => {
+        const rows = text.trim().split('\n').slice(1);
+        const labels = [];
+        const cpu = [];
+        rows.forEach(r => {
+          const parts = r.split(',');
+          labels.push(parts[0]);
+          cpu.push(parseFloat(parts[1]));
+        });
+        new Chart(document.getElementById('chart'), {
+          type: 'bar',
+          data: {
+            labels: labels,
+            datasets: [{ label: 'CPU %', data: cpu }]
+          }
+        });
+      });
+  </script>
+</body>
+</html>

--- a/NFL-bench/docker-compose.yml
+++ b/NFL-bench/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+services:
+  nfl-wasm:
+    image: ghcr.io/builtbycorelot/nfl-wasm:latest
+    volumes:
+      - ..:/workspace
+    working_dir: /workspace
+    command: ["sleep", "infinity"]
+
+  node-red:
+    image: nodered/node-red:latest
+    ports:
+      - "1880:1880"
+    volumes:
+      - ./results:/data/results
+
+  neo4j:
+    image: neo4j:5
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      - NEO4J_AUTH=neo4j/neo4j123
+    volumes:
+      - neo4j-data:/data
+
+volumes:
+  neo4j-data:

--- a/NFL-bench/runner.sh
+++ b/NFL-bench/runner.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Orchestrate the benchmark harness.
+# Usage: ./runner.sh [workload]
+set -euo pipefail
+
+COMPOSE="docker-compose"
+WORKLOAD=${1:-workloads/synthetic.json}
+
+$COMPOSE up -d
+
+echo "Warm-up phase..."
+sleep 5
+
+NODE_RED_ID=$($COMPOSE ps -q node-red)
+
+if [ -f "$WORKLOAD" ]; then
+  echo "Streaming workload $WORKLOAD"
+  docker cp "$WORKLOAD" "$NODE_RED_ID:/data/workload.json"
+fi
+
+# Placeholder for custom workload execution
+# Here we just wait a fixed time to simulate processing
+sleep 10
+
+echo "Collecting metrics..."
+echo "container,cpu,mem" > results/metrics.csv
+docker stats --no-stream --format '{{.Name}},{{.CPUPerc}},{{.MemUsage}}' "$NODE_RED_ID" >> results/metrics.csv
+
+$COMPOSE down

--- a/NFL-bench/workloads/generate_workload.py
+++ b/NFL-bench/workloads/generate_workload.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Generate synthetic workloads for NFL benchmarking."""
+import argparse
+import json
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("out", help="Output JSON file")
+    parser.add_argument("-n", "--nodes", type=int, default=10, help="Number of nodes")
+    args = parser.parse_args()
+
+    events = []
+    for i in range(args.nodes):
+        events.append({"id": i + 1, "action": "create", "type": "node", "value": f"N{i}"})
+    for i in range(args.nodes - 1):
+        events.append({"id": args.nodes + i + 1, "action": "edge", "from": f"N{i}", "to": f"N{i+1}"})
+
+    with open(args.out, "w", encoding="utf-8") as fh:
+        json.dump(events, fh, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/NFL-bench/workloads/synthetic.json
+++ b/NFL-bench/workloads/synthetic.json
@@ -1,0 +1,5 @@
+[
+  {"id": 1, "action": "create", "type": "node", "value": "A"},
+  {"id": 2, "action": "create", "type": "node", "value": "B"},
+  {"id": 3, "action": "edge", "from": "A", "to": "B"}
+]

--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@ See [`docs/context.md`](docs/context.md) for a high level summary and links to r
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+
+## Benchmark Harness
+
+A lightweight benchmark environment lives in [NFL-bench](NFL-bench/). Start the services and run the sample workload using:
+
+```bash
+cd NFL-bench
+docker-compose up -d
+./runner.sh
+```
+
+Metrics are written under `NFL-bench/results`. Open `NFL-bench/dashboard.html` in a browser to visualize the run.


### PR DESCRIPTION
## Summary
- add `NFL-bench` harness with compose file
- add workload generator, sample workload and results folder
- provide runner script and dashboard
- document harness usage in `README`

## Testing
- `pytest -q` *(fails: SyntaxError in cli/nfl_cli.py)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a lightweight benchmarking harness for the NodeForm Language runtime, including setup scripts and sample workloads.
  - Added a dashboard for visualizing benchmark metrics in a browser.
  - Provided scripts to generate custom workloads and run benchmarks with Docker Compose.
- **Documentation**
  - Added detailed instructions for setup, running benchmarks, and viewing results in the README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->