### PR TITLE
Extend DSL parser with field support

### DIFF
--- a/tests/test_dsl_parser.py
+++ b/tests/test_dsl_parser.py
@@ -1,0 +1,37 @@
+from cli.dsl_to_json import parse_file
+
+
+def test_parse_node_fields(tmp_path):
+    dsl = tmp_path / "sample.dsl"
+    dsl.write_text(
+        """
+namespace demo
+
+node Person {
+    name: string
+    age: int
+}
+
+node Task {
+    title: string
+}
+
+edge Person -> Task
+edge Task:title -> Person
+""",
+        encoding="utf-8",
+    )
+
+    data = parse_file(str(dsl))
+    assert data["pack"] == "demo"
+    names = [n["name"] for n in data["nodes"]]
+    assert "Person" in names and "Task" in names
+
+    person = next(n for n in data["nodes"] if n["name"] == "Person")
+    fields = {f["name"]: f["type"] for f in person["fields"]}
+    assert fields == {"name": "string", "age": "int"}
+
+    edges = data["edges"]
+    assert {"from": "Person", "to": "Task"} in edges
+    assert {"from": "Task", "from_field": "title", "to": "Person"} in edges
+


### PR DESCRIPTION
## Summary
- enhance `parse_file` to read node blocks and parse `field: type`
- clean up `nfl_converters` module
- add tests for DSL node field parsing

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced DSL parsing to support multi-line node definitions with fields.
- **Bug Fixes**
  - Improved validation and error handling in graph conversion functions to prevent malformed outputs.
- **Tests**
  - Added a test to verify correct parsing of node fields in DSL files.
- **Refactor**
  - Consolidated graph validation logic and updated JSON output to produce JSON-LD format.
  - Simplified CityJSON output by removing attributes and return value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->