### PR TITLE
Fix indentation to restore tests

### DIFF
--- a/nfl_converters.py
+++ b/nfl_converters.py
@@ -7,23 +7,30 @@ from typing import Any, Dict, List
 
 from cli.nfl_to_semantics import convert_to_jsonld
 
+
 def to_json(nfl: Dict[str, Any]) -> str:
     """Return the NFL graph as pretty JSON."""
     _validate_graph(nfl)
     return json.dumps(nfl, indent=2, sort_keys=True)
+
 
 def _validate_graph(nfl: Dict[str, Any]) -> None:
     """Raise :class:`ValueError` if *nfl* doesn't look like a graph."""
     if not isinstance(nfl, dict) or not all(k in nfl for k in ["nodes", "edges"]):
         raise ValueError("Input must be a valid NFL graph with 'nodes' and 'edges' keys")
 
-def to_json(nfl: Dict[str, Any]) -> str:
-    """Return the NFL graph as pretty JSON."""
+
+def to_jsonld(nfl: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a JSON-LD representation of *nfl*."""
     _validate_graph(nfl)
     return convert_to_jsonld(nfl)
 
-def to_owl(nfl: Dict[str, Any]) -> str:
 
+def to_owl(nfl: Dict[str, Any]) -> str:
+    """Return an OWL/Turtle representation of *nfl*."""
+    _validate_graph(nfl)
+
+    lines: List[str] = [
         "@prefix nfl: <http://example.org/nfl#> .",
         "@prefix owl: <http://www.w3.org/2002/07/owl#> .",
         "",
@@ -44,13 +51,16 @@ def to_owl(nfl: Dict[str, Any]) -> str:
 
     return "\n".join(lines)
 
+
 def to_cityjson(nfl: Dict[str, Any]) -> Dict[str, Any]:
     """Return a simple CityJSON representation of *nfl*."""
     _validate_graph(nfl)
 
     city_objects: Dict[str, Any] = {}
     for node in nfl.get("nodes", []):
-
+        obj = {
+            "type": node.get("type", "Unknown"),
+            "attributes": {k: v for k, v in node.items() if k not in {"name", "type", "lat", "lon"}},
         }
         if "lat" in node and "lon" in node:
             obj["geometry"] = [
@@ -60,6 +70,9 @@ def to_cityjson(nfl: Dict[str, Any]) -> Dict[str, Any]:
                 }
             ]
         city_objects[node.get("name")] = obj
+
+    return {"type": "CityJSON", "version": "1.1", "CityObjects": city_objects}
+
 
 def to_geojson(nfl: Dict[str, Any]) -> Dict[str, Any]:
     """Return a GeoJSON ``FeatureCollection`` for the graph."""


### PR DESCRIPTION
## Summary
- restore `nfl_converters.py` after accidental truncation
- confirm tests run successfully

## Testing
- `pytest -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for exporting NFL graph data to JSON-LD format.
- **Improvements**
  - Enhanced CityJSON export to include full metadata and geometry information when available.
  - Improved OWL export with better input validation and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->