### PR TITLE
Improve benchmark dashboard

### DIFF
--- a/NFL-bench/dashboard.html
+++ b/NFL-bench/dashboard.html
@@ -15,16 +15,29 @@
         const rows = text.trim().split('\n').slice(1);
         const labels = [];
         const cpu = [];
+        const mem = [];
         rows.forEach(r => {
           const parts = r.split(',');
           labels.push(parts[0]);
           cpu.push(parseFloat(parts[1]));
+          // Extract the numeric portion of memory usage like "12.3MiB / 512MiB"
+          const memVal = parseFloat(parts[2].split(' ')[0]);
+          mem.push(memVal);
         });
         new Chart(document.getElementById('chart'), {
           type: 'bar',
           data: {
             labels: labels,
-            datasets: [{ label: 'CPU %', data: cpu }]
+            datasets: [
+              { label: 'CPU %', data: cpu, yAxisID: 'y' },
+              { label: 'Mem (MiB)', data: mem, yAxisID: 'y1', backgroundColor: 'rgba(153, 102, 255, 0.5)' }
+            ]
+          },
+          options: {
+            scales: {
+              y: { beginAtZero: true, position: 'left' },
+              y1: { beginAtZero: true, position: 'right', grid: { drawOnChartArea: false } }
+            }
           }
         });
       });

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ docker-compose up -d
 ./runner.sh
 ```
 
-Metrics are written under `NFL-bench/results`. Open `NFL-bench/dashboard.html` in a browser to visualize the run.
+Metrics are written under `NFL-bench/results`. Open `NFL-bench/dashboard.html` in a browser to visualize CPU and memory usage.


### PR DESCRIPTION
## Summary
- show memory usage next to CPU on `NFL-bench/dashboard.html`
- update instructions in README

## Testing
- `git status --short`