### PR TITLE
Add Docker setup for local deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.access.redhat.com/ubi9/python-39
 WORKDIR /opt/app
-COPY requirements.txt .
+COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
+# Copy the rest of the source afterwards to keep the cache
+COPY . ./
 RUN pip install --no-cache-dir .
 CMD ["python", "-m", "cli.nfl_cli", "--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi9/python-39
+WORKDIR /opt/app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+RUN pip install --no-cache-dir .
+CMD ["python", "-m", "cli.nfl_cli", "--help"]

--- a/README.md
+++ b/README.md
@@ -40,4 +40,13 @@ This project is licensed under the [MIT License](LICENSE).
 
 ## Benchmark Harness
 
-In Deepnote
+
+## Docker Compose
+
+To launch the NFL application together with Neo4j, PostgreSQL and an Apache server run:
+
+```bash
+docker-compose up
+```
+
+This builds the project image and starts all services for a local deployment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+services:
+  nfl:
+    build: .
+    command: python -m cli.nfl_cli --help
+    volumes:
+      - .:/opt/app
+    depends_on:
+      - neo4j
+      - postgres
+    ports:
+      - "8080:8080"
+
+  neo4j:
+    image: neo4j:latest
+    environment:
+      - NEO4J_AUTH=neo4j/test
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+
+  postgres:
+    image: postgres:alpine
+    environment:
+      POSTGRES_USER: nfl
+      POSTGRES_PASSWORD: nfl
+      POSTGRES_DB: nfl
+    ports:
+      - "5432:5432"
+
+  apache:
+    image: httpd:alpine
+    volumes:
+      - ./index.html:/usr/local/apache2/htdocs/index.html:ro
+      - ./overview.html:/usr/local/apache2/htdocs/overview.html:ro
+      - ./visualizer.html:/usr/local/apache2/htdocs/visualizer.html:ro
+      - ./explorer.html:/usr/local/apache2/htdocs/explorer.html:ro
+    ports:
+      - "80:80"


### PR DESCRIPTION
## Summary
- add Dockerfile using RedHat UBI base
- define docker-compose services for the app, Neo4j, PostgreSQL and Apache
- document how to launch everything with `docker-compose up`

## Testing
- `pytest -q` *(fails: FileNotFoundError - missing example files)*

------
https://chatgpt.com/codex/tasks/task_e_685b2ad263a483338d487622fb6a9afe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Docker support for the application, enabling containerized deployment.
  - Introduced a Docker Compose setup to easily launch the application alongside Neo4j, PostgreSQL, and Apache services.
- **Documentation**
  - Updated the README with instructions for running the application and its dependencies using Docker Compose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->