### PR TITLE
Add stateful nodes and edge validation

### DIFF
--- a/cli/nfl_to_semantics.py
+++ b/cli/nfl_to_semantics.py
@@ -20,12 +20,15 @@ def convert_to_jsonld(nfl: Dict[str, Any]) -> Dict[str, Any]:
     graph: List[Dict[str, Any]] = []
 
     for node in nfl.get("nodes", []):
-        graph.append({
+        entry = {
             "@id": node.get("name"),
             "@type": "Node",
             "name": node.get("name"),
             "type": node.get("type"),
-        })
+        }
+        if "state" in node:
+            entry["state"] = node["state"]
+        graph.append(entry)
 
     for edge in nfl.get("edges", []):
         graph.append({
@@ -50,7 +53,12 @@ def convert_to_owl(nfl: Dict[str, Any]) -> str:
 
     for node in nfl.get("nodes", []):
         lines.append(f":{node.get('name')} a owl:NamedIndividual ;")
-        lines.append(f"    :type \"{node.get('type')}\" .")
+        type_line = f"    :type \"{node.get('type')}\""
+        if "state" in node:
+            lines.append(type_line + " ;")
+            lines.append(f"    :state '{json.dumps(node['state'])}' .")
+        else:
+            lines.append(type_line + " .")
 
     for edge in nfl.get("edges", []):
         lines.append(f":{edge.get('from')} :connectedTo :{edge.get('to')} .")

--- a/docs/context.md
+++ b/docs/context.md
@@ -10,5 +10,10 @@ NFL is a minimalist graph notation for describing knowledge and processes. It re
 | `trait` | annotate behavior or attach data |
 | `pack` | group a dialect or namespace |
 | `impl` | provide the implementation |
+| `state` | capture persistent values for a node |
 
-Graphs built from these verbs can be validated and executed across runtimes. The repository provides examples, a JSON schema, and tooling to explore NFL data.
+Graphs built from these verbs can include optional state data on nodes. The
+``state`` field is free-form JSON that allows implementations to persist runtime
+values alongside the structural description. Graphs can be validated and
+executed across runtimes. The repository provides examples, a JSON schema, and
+tooling to explore NFL data.

--- a/docs/crosswalks.md
+++ b/docs/crosswalks.md
@@ -10,5 +10,41 @@ Mappings to external vocabularies help NFL interoperate with existing standards.
 - **schema.org** – web entities
 - **node**
 
-TODO: Add NFL Examples and how it defines itself
+Example NFL graph in JSON:
+
+```json
+{
+  "pack": "demo",
+  "nodes": [{"name": "A", "type": "Thing"}],
+  "edges": []
+}
+```
+
+### JSON-LD
+
+```json
+{
+  "@context": "http://schema.org",
+  "@graph": [{"@id": "A", "@type": "Thing", "name": "A"}]
+}
+```
+
+### OWL
+
+```
+:A a :Thing .
+```
+
+### CityJSON
+
+```json
+{
+  "type": "CityJSON",
+  "version": "1.1",
+  "CityObjects": {"A": {"type": "Thing", "attributes": {}}}
+}
+```
+
+NFL uses this graph format to describe itself in `nfl.schema.json`, which
+specifies the required fields for nodes and edges.
 

--- a/examples/stateful.json
+++ b/examples/stateful.json
@@ -1,0 +1,7 @@
+{
+  "pack": "state.test",
+  "nodes": [
+    {"name": "counter", "type": "int", "state": {"value": 0}}
+  ],
+  "edges": []
+}

--- a/nfl.js
+++ b/nfl.js
@@ -55,7 +55,11 @@ export function convertFromNFL(content, format) {
     case 'jsonld': {
       const items = [];
       for (const [id, n] of Object.entries(graph.nodes)) {
-        items.push({ '@id': id, '@type': 'Thing', name: n.label, ...n.traits });
+        const obj = { '@id': id, '@type': 'Thing', name: n.label, ...n.traits };
+        if (n.state !== undefined) {
+          obj.state = n.state;
+        }
+        items.push(obj);
       }
       for (const e of graph.edges) {
         items.push({ '@type': 'Relationship', from: e.source, to: e.target, relationship: e.relationship_type });
@@ -76,6 +80,9 @@ export function convertFromNFL(content, format) {
         for (const [k, v] of Object.entries(n.traits)) {
           out += `\n  ${k}: "${v}"`;
         }
+        if (n.state !== undefined) {
+          out += `\n  state: ${JSON.stringify(n.state)}`;
+        }
         out += `\n`;
       }
       return out;
@@ -83,7 +90,11 @@ export function convertFromNFL(content, format) {
     case 'geojson': {
       const features = [];
       for (const [id, n] of Object.entries(graph.nodes)) {
-        features.push({ type: 'Feature', properties: { id, label: n.label, ...n.traits }, geometry: null });
+        const props = { id, label: n.label, ...n.traits };
+        if (n.state !== undefined) {
+          props.state = n.state;
+        }
+        features.push({ type: 'Feature', properties: props, geometry: null });
       }
       return JSON.stringify({ type: 'FeatureCollection', features }, null, 2);
     }

--- a/nfl_converters.py
+++ b/nfl_converters.py
@@ -42,6 +42,10 @@ def to_owl(nfl: Dict[str, Any]) -> str:
         typ = node.get("type", "Node")
         if name:
             lines.append(f"nfl:{name} a nfl:{typ} .")
+            if "state" in node:
+                lines.append(
+                    f"nfl:{name} nfl:hasState '{json.dumps(node['state'])}' ."
+                )
 
     for edge in nfl.get("edges", []):
         from_node = edge.get("from")

--- a/schema/nfl.schema.json
+++ b/schema/nfl.schema.json
@@ -11,6 +11,7 @@
         "properties": {
           "name": { "type": "string" },
           "type": { "type": "string" },
+          "state": { "type": "object" },
           "trait": {
             "type": "array",
             "items": { "type": "string" }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ def test_validate_file_valid():
 def test_validate_file_invalid(tmp_path):
     invalid = tmp_path / "invalid.json"
     invalid.write_text("{}", encoding="utf-8")
-    with pytest.raises(Exception):
+    with pytest.raises((ValueError, json.JSONDecodeError)):
         validate_file(str(invalid), SCHEMA_PATH)
 
 

--- a/tests/test_nfl.py
+++ b/tests/test_nfl.py
@@ -25,7 +25,7 @@ class ValidateFileTests(unittest.TestCase):
             tmp.write("{}")
             tmp_path = tmp.name
         try:
-            with self.assertRaises(Exception):
+            with self.assertRaises(ValueError):  # or the specific exception type used
                 nfl_cli.validate_file(tmp_path, SCHEMA_PATH)
         finally:
             os.remove(tmp_path)

--- a/tests/test_nfl.py
+++ b/tests/test_nfl.py
@@ -25,7 +25,8 @@ class ValidateFileTests(unittest.TestCase):
             tmp.write("{}")
             tmp_path = tmp.name
         try:
-            self.assertFalse(nfl_cli.validate_file(tmp_path, SCHEMA_PATH))
+            with self.assertRaises(Exception):
+                nfl_cli.validate_file(tmp_path, SCHEMA_PATH)
         finally:
             os.remove(tmp_path)
 


### PR DESCRIPTION
## Summary
- support optional `state` field in schema
- preserve `state` in converters and js utilities
- improve CLI validation with edge checks and exceptions
- add stateful example and new docs
- complete crosswalk documentation
- update tests for new API and features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b51e51f3c8333b43869fa6b9d9591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional "state" property on nodes, allowing persistent values to be captured and exported in various formats (JSON-LD, OWL, GeoJSON, YAML).
  - Updated the schema and documentation to describe the new "state" attribute and its usage.

- **Bug Fixes**
  - Improved error reporting during file validation, providing clearer feedback when validation fails.

- **Documentation**
  - Expanded documentation with examples illustrating the new "state" feature and crosswalks to external formats.
  - Updated schema documentation to include the "state" property.

- **Tests**
  - Enhanced tests to verify correct handling and validation of the new "state" property and improved error handling.

- **Chores**
  - Added a new example file demonstrating a stateful node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->