### PR TITLE
Add Docker verification docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ docker-compose up
 
 This builds the project image and starts all services for a local deployment.
 
+After the containers come up you can verify everything is running with:
+
+```bash
+docker-compose ps
+```
+
+You should see `nfl`, `neo4j`, `postgres` and `apache` listed as `Up`. Open
+`http://localhost` in your browser to confirm the HTML pages load. See
+[docs/docker.md](docs/docker.md) for more details.
+
 ## Quickstart
 
 Install the package in editable mode and run the CLI:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,44 @@
+# Docker Deployment
+
+Follow these steps to run the NFL stack with Docker.
+
+## Prerequisites
+
+Ensure Docker and Docker Compose are installed. Verify with:
+
+```bash
+docker --version
+docker-compose --version
+```
+
+Both commands should print version information.
+
+## Start Services
+
+From the repository root run:
+
+```bash
+docker-compose up
+```
+
+This builds the `nfl` image and starts Neo4j, PostgreSQL and Apache. The first run may take a few minutes.
+
+## Verify
+
+Check the status of the containers:
+
+```bash
+docker-compose ps
+```
+
+All services should be listed as `Up`. You can then browse to [http://localhost](http://localhost) to see the web pages served by Apache. Neo4j is available on port `7474` and PostgreSQL on `5432`.
+
+## Shutdown
+
+Press `Ctrl+C` and then run:
+
+```bash
+docker-compose down
+```
+
+This stops and removes the containers.


### PR DESCRIPTION
## Summary
- expand README with instructions to verify the Docker stack
- add a new `docs/docker.md` explaining how to deploy and check containers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862bf1cc8148333be85301bb4c03510