### PR TITLE
Improve Docker docs and schema validation

### DIFF
--- a/cli/nfl_cli.py
+++ b/cli/nfl_cli.py
@@ -46,7 +46,10 @@ def validate_file(nfl_path: str, schema_path: str) -> bool:
         if not (isinstance(nfl, dict) and "nodes" in nfl and "edges" in nfl):
             raise ValueError("Input is not a valid NFL graph")
     else:
-        jsonschema.validate(nfl, schema)
+        try:
+            jsonschema.validate(nfl, schema)
+        except jsonschema.exceptions.ValidationError as exc:
+            raise ValueError(exc.message) from exc
 
     node_names = {n.get("name") for n in nfl.get("nodes", [])}
     for edge in nfl.get("edges", []):

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -42,3 +42,35 @@ docker-compose down
 ```
 
 This stops and removes the containers.
+
+## Testing with Docker Desktop
+
+Windows users can run the stack inside Docker Desktop using a short PowerShell
+script. Save the following as `run-docker.ps1` in the repository root:
+
+```powershell
+docker-compose up --build *>&1 | Tee-Object -FilePath nfl_docker.log
+```
+
+Execute the script from a PowerShell prompt:
+
+```powershell
+./run-docker.ps1
+```
+
+The command streams container logs to the console while also saving them to
+`nfl_docker.log`. Look for messages such as `Bolt enabled on 0.0.0.0:7687` or
+`Usage: nfl-cli` to confirm each service starts correctly. Press `Ctrl+C` to
+stop and then run:
+
+```powershell
+docker-compose down
+```
+
+to remove the containers. You can inspect the saved log file later with
+
+```powershell
+Get-Content .\nfl_docker.log -Tail 20
+```
+
+or by opening `nfl_docker.log` in a text editor.

--- a/run-docker.ps1
+++ b/run-docker.ps1
@@ -1,0 +1,3 @@
+# Start the compose stack and log output to nfl_docker.log
+docker-compose up --build *>&1 | Tee-Object -FilePath nfl_docker.log -Append
+


### PR DESCRIPTION
## Summary
- show how to inspect docker logs when running via PowerShell
- append logs in `run-docker.ps1`
- raise `ValueError` when schema validation fails

## Testing
- `pytest -q`
- `pytest --cov=./ --cov-report=xml` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68653c95eef08333942db7f400f6b127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PowerShell script for Windows users to run the Docker stack and log output to a file.
* **Documentation**
  * Updated Docker deployment instructions with a new section for Windows users, detailing how to use the provided PowerShell script.
* **Bug Fixes**
  * Improved error handling for JSON Schema validation by providing clearer error messages when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->