### PR TITLE
Add Flask API and docker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ After the containers come up you can verify everything is running with:
 docker-compose ps
 ```
 
-You should see `nfl`, `neo4j`, `postgres` and `apache` listed as `Up`. Open
-`http://localhost` in your browser to confirm the HTML pages load. See
+You should see `nfl`, `api`, `neo4j`, `postgres` and `apache` listed as `Up`.
+The API server listens on `http://localhost:10000` for requests. Open
+`http://localhost` to confirm the HTML pages load. See
 [docs/docker.md](docs/docker.md) for more details.
 
 ## Quickstart

--- a/app.py
+++ b/app.py
@@ -1,0 +1,270 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+import json
+import sqlite3
+from neo4j import GraphDatabase
+import os
+from datetime import datetime
+
+app = Flask(__name__)
+CORS(app)
+
+# Configuration
+NEO4J_URI = os.getenv('NEO4J_URI', 'bolt://localhost:7687')
+NEO4J_USER = os.getenv('NEO4J_USER', 'neo4j')
+NEO4J_PASSWORD = os.getenv('NEO4J_PASSWORD', 'password')
+SQLITE_DB = os.getenv('SQLITE_DB', 'nfl.db')
+
+# Neo4j driver
+driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+
+# Initialize SQLite database
+def init_sqlite():
+    conn = sqlite3.connect(SQLITE_DB)
+    cursor = conn.cursor()
+
+    # Create tables for NFL data
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS teams (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            city TEXT,
+            conference TEXT,
+            division TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    ''')
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS players (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            team_id TEXT,
+            position TEXT,
+            jersey_number INTEGER,
+            height REAL,
+            weight REAL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (team_id) REFERENCES teams(id)
+        )
+    ''')
+
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS games (
+            id TEXT PRIMARY KEY,
+            home_team_id TEXT,
+            away_team_id TEXT,
+            home_score INTEGER,
+            away_score INTEGER,
+            game_date DATE,
+            season INTEGER,
+            week INTEGER,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (home_team_id) REFERENCES teams(id),
+            FOREIGN KEY (away_team_id) REFERENCES teams(id)
+        )
+    ''')
+
+    conn.commit()
+    conn.close()
+
+# Initialize on startup
+init_sqlite()
+
+@app.route('/health', methods=['GET'])
+def health():
+    return jsonify({'status': 'healthy', 'service': 'NFL Query API'})
+
+@app.route('/api/cypher', methods=['POST'])
+def execute_cypher():
+    """
+    Execute Cypher queries against Neo4j graph database
+
+    Expected JSON payload:
+    {
+        "query": "MATCH (t:Team)-[:HAS_PLAYER]->(p:Player) WHERE t.name = $team_name RETURN p",
+        "parameters": {"team_name": "Cowboys"}
+    }
+    """
+    try:
+        data = request.json
+        query = data.get('query')
+        parameters = data.get('parameters', {})
+
+        if not query:
+            return jsonify({'error': 'Query is required'}), 400
+
+        # Security: Basic query validation (expand as needed)
+        forbidden_keywords = ['DELETE', 'DROP', 'CREATE INDEX', 'CREATE CONSTRAINT']
+        if any(keyword in query.upper() for keyword in forbidden_keywords):
+            return jsonify({'error': 'Forbidden operation'}), 403
+
+        results = []
+        with driver.session() as session:
+            result = session.run(query, parameters)
+            for record in result:
+                results.append(dict(record))
+
+        return jsonify({
+            'success': True,
+            'data': results,
+            'count': len(results),
+            'query': query,
+            'timestamp': datetime.utcnow().isoformat()
+        })
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e),
+            'type': 'cypher_error'
+        }), 500
+
+@app.route('/api/sql', methods=['POST'])
+def execute_sql():
+    """
+    Execute SQL queries against SQLite database
+
+    Expected JSON payload:
+    {
+        "query": "SELECT * FROM teams WHERE conference = ?",
+        "parameters": ["NFC"]
+    }
+    """
+    try:
+        data = request.json
+        query = data.get('query')
+        parameters = data.get('parameters', [])
+
+        if not query:
+            return jsonify({'error': 'Query is required'}), 400
+
+        # Security: Only allow SELECT queries
+        if not query.strip().upper().startswith('SELECT'):
+            return jsonify({'error': 'Only SELECT queries are allowed'}), 403
+
+        conn = sqlite3.connect(SQLITE_DB)
+        conn.row_factory = sqlite3.Row  # Enable column access by name
+        cursor = conn.cursor()
+
+        cursor.execute(query, parameters)
+        rows = cursor.fetchall()
+
+        # Convert rows to dictionaries
+        results = [dict(row) for row in rows]
+
+        conn.close()
+
+        return jsonify({
+            'success': True,
+            'data': results,
+            'count': len(results),
+            'query': query,
+            'timestamp': datetime.utcnow().isoformat()
+        })
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e),
+            'type': 'sql_error'
+        }), 500
+
+@app.route('/api/import', methods=['POST'])
+def import_nfl_data():
+    """
+    Import NFL JSON data into both databases
+    """
+    try:
+        data = request.json
+
+        # Validate against NFL schema first
+        # ... validation logic ...
+
+        # Import to SQLite
+        conn = sqlite3.connect(SQLITE_DB)
+        cursor = conn.cursor()
+
+        # Import teams
+        for team in data.get('teams', []):
+            cursor.execute('''
+                INSERT OR REPLACE INTO teams (id, name, city, conference, division)
+                VALUES (?, ?, ?, ?, ?)
+            ''', (team['id'], team['name'], team.get('city'),
+                  team.get('conference'), team.get('division')))
+
+        conn.commit()
+        conn.close()
+
+        # Import to Neo4j
+        with driver.session() as session:
+            # Clear existing data
+            session.run("MATCH (n) DETACH DELETE n")
+
+            # Import teams as nodes
+            for team in data.get('teams', []):
+                session.run("""
+                    CREATE (t:Team {
+                        id: $id,
+                        name: $name,
+                        city: $city,
+                        conference: $conference,
+                        division: $division
+                    })
+                """, team)
+
+        return jsonify({
+            'success': True,
+            'message': 'Data imported successfully',
+            'timestamp': datetime.utcnow().isoformat()
+        })
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+# Example queries endpoint for documentation
+@app.route('/api/examples', methods=['GET'])
+def get_examples():
+    return jsonify({
+        'cypher_examples': [
+            {
+                'description': 'Find all players on a specific team',
+                'query': 'MATCH (t:Team {name: $team})-[:HAS_PLAYER]->(p:Player) RETURN p.name, p.position',
+                'parameters': {'team': 'Cowboys'}
+            },
+            {
+                'description': 'Find teams in same division',
+                'query': 'MATCH (t1:Team)-[:IN_DIVISION]->(d:Division)<-[:IN_DIVISION]-(t2:Team) WHERE t1.name = $team RETURN t2.name',
+                'parameters': {'team': 'Eagles'}
+            },
+            {
+                'description': 'Player connections through trades',
+                'query': 'MATCH path = (p1:Player)-[:TRADED_WITH*1..3]-(p2:Player) WHERE p1.name = $player RETURN path',
+                'parameters': {'player': 'Tom Brady'}
+            }
+        ],
+        'sql_examples': [
+            {
+                'description': 'Get team standings by conference',
+                'query': 'SELECT name, city, division FROM teams WHERE conference = ? ORDER BY division, name',
+                'parameters': ['AFC']
+            },
+            {
+                'description': 'Find games by score difference',
+                'query': 'SELECT * FROM games WHERE ABS(home_score - away_score) > ? ORDER BY game_date DESC',
+                'parameters': [20]
+            },
+            {
+                'description': 'Player stats by position',
+                'query': 'SELECT position, COUNT(*) as count, AVG(height) as avg_height FROM players GROUP BY position',
+                'parameters': []
+            }
+        ]
+    })
+
+if __name__ == '__main__':
+    port = int(os.getenv('PORT', 10000))
+    app.run(host='0.0.0.0', port=port)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,20 @@ services:
     ports:
       - "8080:8080"
 
+  api:
+    build: .
+    command: python app.py
+    volumes:
+      - .:/opt/app
+    depends_on:
+      - neo4j
+    environment:
+      - NEO4J_URI=bolt://neo4j:7687
+      - NEO4J_USER=neo4j
+      - NEO4J_PASSWORD=test
+    ports:
+      - "10000:10000"
+
   neo4j:
     image: neo4j:latest
     environment:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,16 @@
+# API Server
+
+The API container exposes HTTP endpoints for querying the local Neo4j and SQLite
+instances. It starts automatically when running `docker-compose up` and listens
+on port `10000`.
+
+## Endpoints
+
+- `GET /health` – simple health check returning service status.
+- `POST /api/cypher` – execute Cypher queries against Neo4j.
+- `POST /api/sql` – run read-only SQL against the bundled SQLite database.
+- `POST /api/import` – import NFL JSON data into both databases.
+- `GET /api/examples` – sample requests for each API.
+
+All endpoints accept and return JSON. Environment variables control database
+locations and credentials when running inside Docker.

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -21,7 +21,8 @@ From the repository root run:
 docker-compose up
 ```
 
-This builds the `nfl` image and starts Neo4j, PostgreSQL and Apache. The first run may take a few minutes.
+This builds the `nfl` image and starts the API server along with Neo4j,
+PostgreSQL and Apache. The first run may take a few minutes.
 
 ## Verify
 
@@ -31,7 +32,9 @@ Check the status of the containers:
 docker-compose ps
 ```
 
-All services should be listed as `Up`. You can then browse to [http://localhost](http://localhost) to see the web pages served by Apache. Neo4j is available on port `7474` and PostgreSQL on `5432`.
+All services should be listed as `Up`. The API is reachable on port `10000`.
+You can browse to [http://localhost](http://localhost) to see the web pages
+served by Apache. Neo4j is available on port `7474` and PostgreSQL on `5432`.
 
 ## Shutdown
 

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <li><a href="docs/context.md">Context</a></li>
     <li><a href="docs/ledger.md">SemanticLedger</a></li>
     <li><a href="docs/crosswalks.md">Crosswalks</a></li>
+    <li><a href="docs/api.md">API Server</a></li>
   </ul>
   <p>See the <a href="https://builtbycorelot.github.io/NFL">GitHub Pages site</a> for a hosted version.</p>
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 pytest
 jsonschema
+
+flask
+flask-cors
+neo4j


### PR DESCRIPTION
## Summary
- implement public API server in `app.py`
- include dependencies for Flask, CORS and Neo4j
- expose API container through docker-compose
- document API usage and update docs with API details
- link API docs from site index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bde46ce88333b4408b79521913ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an API server for querying and managing NFL data via HTTP endpoints, supporting both Neo4j and SQLite databases.
  * Added endpoints for health checks, Cypher and SQL queries, data import, and example requests.
  * Provided API documentation detailing available endpoints and usage.

* **Documentation**
  * Updated instructions to include the new API server in Docker setup and container verification steps.
  * Clarified API server access details and linked API documentation from the main documentation page.

* **Chores**
  * Added required Python packages for the API server to the dependencies list.
  * Updated Docker configuration to include and configure the new API server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->