### PR TITLE
Update Docker for Render

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Compose Smoke Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  healthcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: API healthcheck
+        run: |
+          docker compose up -d nfl
+          sleep 20
+          curl --fail http://localhost:8080/health

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM registry.access.redhat.com/ubi9/python-39
+FROM python:3.11-slim
 WORKDIR /opt/app
-COPY requirements.txt ./
+
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-# Copy the rest of the source afterwards to keep the cache
-COPY . ./
-RUN pip install --no-cache-dir .
-CMD ["python", "-m", "cli.nfl_cli", "--help"]
+
+COPY . .
+
+EXPOSE 8080
+ENV PORT 8080
+
+CMD ["gunicorn", "-b", "0.0.0.0:${PORT:-8080}", "app:app"]

--- a/README.md
+++ b/README.md
@@ -59,9 +59,25 @@ docker-compose ps
 ```
 
 You should see `nfl`, `api`, `neo4j`, `postgres` and `apache` listed as `Up`.
-The API server listens on `http://localhost:10000` for requests. Open
-`http://localhost` to confirm the HTML pages load. See
-[docs/docker.md](docs/docker.md) for more details.
+The API server listens on `http://localhost:8080` for requests. Open
+`http://localhost` to confirm the HTML pages load. The HTML under `/docs`
+is served by the Apache container when running `docker-compose` locally.
+See [docs/docker.md](docs/docker.md) for more details.
+
+## Deploy on Render
+
+```
+Service type: Web Service
+Build Command: (leave blank)
+Start Command: (leave blank)
+Health Check path: /health
+Env vars: NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
+```
+
+Render maps `$PORT` to `8080` automatically. Create a second service if you
+need a private Neo4j container or point the variables at an AuraDB instance.
+The API routes live at the root domain on Render, so navigate to
+`https://your-app.onrender.com/health` instead of `/api/health`.
 
 ## Quickstart
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   nfl:
     build: .
-    command: python -m cli.nfl_cli --help
+    command: gunicorn -b 0.0.0.0:${PORT:-8080} app:app
     volumes:
       - .:/opt/app
     depends_on:

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,7 +2,11 @@
 
 The API container exposes HTTP endpoints for querying the local Neo4j and SQLite
 instances. It starts automatically when running `docker-compose up` and listens
-on port `10000`.
+on port `8080`.
+
+When using `docker-compose` locally the Apache container serves this
+documentation under the `/docs` path. On Render the API is hosted at the root
+domain instead, so `/health` is reachable at `https://your-app.onrender.com/health`.
 
 ## Endpoints
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -32,7 +32,7 @@ Check the status of the containers:
 docker-compose ps
 ```
 
-All services should be listed as `Up`. The API is reachable on port `10000`.
+All services should be listed as `Up`. The API is reachable on port `8080`.
 You can browse to [http://localhost](http://localhost) to see the web pages
 served by Apache. Neo4j is available on port `7474` and PostgreSQL on `5432`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,6 @@ jsonschema
 
 flask
 flask-cors
-neo4j
+neo4j-driver
+gunicorn
+python-dotenv


### PR DESCRIPTION
## Summary
- add runtime deps including gunicorn
- trim Dockerfile for long-running API
- run gunicorn in docker-compose
- document Render deployment and local docs path
- note Render base path in API docs
- add smoke-test workflow to spin up the container
- update docs to show API runs on port 8080

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865c05965d08333af3f67dadd4f096d