### PR TITLE
Add test extras and doc instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-- Upcoming changes.
+-
+
+## [0.2.0] - 2025-07-03
+- Fixed PORT expansion in Dockerfile
+- Added database health endpoint and service info route
+- Documentation and badges updated
 
 ## [0.1.0] - 2025-05-22
 - Initial release.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY . .
 EXPOSE 8080
 ENV PORT 8080
 
-CMD ["gunicorn", "-b", "0.0.0.0:${PORT:-8080}", "app:app"]
+CMD ["/bin/sh", "-c", "gunicorn -b 0.0.0.0:${PORT:-8080} app:app"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
-* Node Form Language is a metaframework to organize knowledge and action. 
-* Graphs express relationships 
+![build](https://github.com/builtbycorelot/NFL/actions/workflows/ci.yml/badge.svg)
+![coverage](https://codecov.io/gh/builtbycorelot/NFL/branch/main/graph/badge.svg)
+
+* Node Form Language is a metaframework to organize knowledge and action.
+* Graphs express relationships
 * Hardware trust anchors secure deployments.
-* Minimalist lexicon for precise neural representation of digital and physical constructs. 
+* Minimalist lexicon for precise neural representation of digital and physical constructs.
+
+## Quick Start
+
+```bash
+git clone https://github.com/builtbycorelot/NFL && cd NFL
+docker build -t nfl-api .
+docker run -it --rm -p 8080:8080 \
+    -e PORT=8080 \
+    -e NEO4J_URI=bolt://host.docker.internal:7687 \
+    nfl-api
+curl http://localhost:8080/health
+```
 
 ## Core Verbs
 
@@ -27,9 +42,17 @@ Think of this as distilling ideas from RedNode and Neo4j into a tiny set of verb
 * [Graph IR Viewer](visualizer.html) – loads `index.nfl.json` automatically.
 * [Context](docs/context.md) – repository anchor and semantic index.
 * [CodeRabbit Badge](docs/coderabbit_badge.md) – badge parameters for PR review counts.
+* [Operational Spec](docs/operations.md) – run-book and API reference.
 
 ## Development and Testing
+Install dependencies in editable mode and run the tests:
 
+```bash
+pip install -e .[test]
+pytest -q
+```
+
+Neo4j tests skip automatically if `NEO4J_URI` is unset.
 
 ## Context
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,60 @@
+# NFL Public API – Operational Spec (v0.2)
+
+This document mirrors the operational reference used to run and test the HTTP API.
+It outlines the quick start steps, runtime configuration, API surface and test
+matrix.
+
+## Quick-Start
+
+```bash
+# build & run API on :8080
+$ docker build -t nfl-api .
+$ docker run -it --rm -p 8080:8080 \
+      -e PORT=8080 \
+      -e NEO4J_URI=bolt://host.docker.internal:7687 \
+      nfl-api
+```
+
+Smoke test:
+
+```bash
+curl http://localhost:8080/health  # -> {"status":"ok"}
+```
+
+## Runtime Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORT` | `8080` | Required on Render. TCP port the API binds. |
+| `WORKERS` | `2` | Gunicorn worker count. |
+| `LOG_LEVEL` | `info` | debug/info/warning/error |
+| `NEO4J_URI` | *(empty – SQLite only mode)* | Bolt URI; if unset, Neo4j routes are disabled. |
+| `SQLITE_PATH` | `data/nfl.db` | File path for local embedded SQLite. |
+
+## API Surface
+
+- `GET /health`
+- `GET /db/health`
+- `GET /info`
+- `POST /import`
+- `GET /export/{format}`
+- `POST /query/cypher`
+- `POST /query/sql`
+
+All responses return `{ "ok": true, "data": …, "duration_ms": 42 }` when successful.
+
+## Tests & Coverage
+
+Install dependencies with test extras and run the suite with:
+
+```bash
+pip install -e .[test]
+pytest -q
+```
+
+Neo4j tests automatically skip if `NEO4J_URI` is unset. Coverage results are
+published via Codecov.
+
+## Changelog
+
+*0.2 – Fix `${PORT}` bug; add DB health endpoint; full docs & badges.*

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="nfl",
-    version="0.1.0",
+    version="0.2.0",
     description="NodeForm Language tools",
     author="builtbycorelot",
     license="MIT",
@@ -10,6 +10,18 @@ setup(
     package_data={"schema": ["*.json"]},
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["jsonschema"],
+    install_requires=[
+        "jsonschema",
+        "flask",
+        "flask-cors",
+        "neo4j-driver",
+        "gunicorn",
+        "python-dotenv",
+    ],
+    extras_require={
+        "test": [
+            "pytest",
+        ]
+    },
     entry_points={"console_scripts": ["nfl-cli=cli.nfl_cli:main"]},
 )

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,29 @@
+import app
+from app import app as flask_app
+
+
+def test_health_endpoint():
+    client = flask_app.test_client()
+    resp = client.get('/health')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'status' in data
+
+
+def test_db_health_endpoint():
+    client = flask_app.test_client()
+    resp = client.get('/db/health')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'neo4j' in data
+    assert 'sqlite' in data
+
+
+def test_info_endpoint():
+    client = flask_app.test_client()
+    resp = client.get('/info')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'version' in data
+    assert 'start_time' in data
+


### PR DESCRIPTION
## Summary
- list install steps for running tests in README and ops doc
- include test dependencies and runtime deps in setup.py

## Testing
- `pip install -e .[test]` *(fails: Could not find a version that satisfies requirement)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_6865c39b715c83338e7b12f79cc3f6f4