### PR TITLE
Add Render deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Render maps `$PORT` to `8080` automatically. Create a second service if you
 need a private Neo4j container or point the variables at an AuraDB instance.
 The API routes live at the root domain on Render, so navigate to
 `https://your-app.onrender.com/health` instead of `/api/health`.
+See [docs/render_deployment.md](docs/render_deployment.md) for example
+deployment logs and the public URL.
 
 ## Quickstart
 

--- a/docs/render_deployment.md
+++ b/docs/render_deployment.md
@@ -1,0 +1,16 @@
+# Render Deployment
+
+The application can be deployed on [Render](https://render.com/) using the provided `Dockerfile`. When the service starts successfully the logs contain messages similar to:
+
+```
+2025-07-03T00:01:07.394436752Z [2025-07-03 00:01:07 +0000] [6] [INFO] Starting gunicorn 23.0.0
+2025-07-03T00:01:07.394831578Z [2025-07-03 00:01:07 +0000] [6] [INFO] Listening at: http://0.0.0.0:10000 (6)
+2025-07-03T00:01:13.869382252Z ==> Your service is live 🎉
+2025-07-03T00:01:14.175587471Z ==> Available at your primary URL https://nfl-s9by.onrender.com
+```
+
+Open the primary URL in your browser to verify the deployment:
+
+<https://nfl-s9by.onrender.com>
+
+See [docs/docker.md](docker.md) for local development details.

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
     <li><a href="docs/ledger.md">SemanticLedger</a></li>
     <li><a href="docs/crosswalks.md">Crosswalks</a></li>
     <li><a href="docs/api.md">API Server</a></li>
+    <li><a href="docs/render_deployment.md">Render Deployment</a></li>
+    <li><a href="https://nfl-s9by.onrender.com">Live Service</a></li>
   </ul>
   <p>See the <a href="https://builtbycorelot.github.io/NFL">GitHub Pages site</a> for a hosted version.</p>
 </body>


### PR DESCRIPTION
## Summary
- document Render deployment logs and primary URL
- link to the new documentation from README and index.html

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865c8932a148333b75e623c1d9b5e14