### PR TITLE
Add root landing page with live health metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
 import json
 import sqlite3
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 import time
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='.', static_url_path='')
 CORS(app)
 
 # Configuration
@@ -18,6 +18,11 @@ SQLITE_DB = os.getenv('SQLITE_DB', 'nfl.db')
 
 # Neo4j driver
 driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+
+@app.route('/')
+def root_page():
+    """Serve the index.html landing page with health metrics."""
+    return app.send_static_file('index.html')
 
 # Service metadata
 VERSION = os.getenv("NFL_VERSION", "0.2.0")

--- a/index.html
+++ b/index.html
@@ -22,5 +22,32 @@
     <li><a href="https://nfl-s9by.onrender.com">Live Service</a></li>
   </ul>
   <p>See the <a href="https://builtbycorelot.github.io/NFL">GitHub Pages site</a> for a hosted version.</p>
+
+  <h2>Service Health</h2>
+  <pre id="health">Loading...</pre>
+
+  <script>
+    async function loadHealth() {
+      try {
+        const [dbResp, infoResp] = await Promise.all([
+          fetch('db/health'),
+          fetch('info')
+        ]);
+        const db = await dbResp.json();
+        const info = await infoResp.json();
+        const lines = [
+          `Neo4j: ${db.neo4j} (${db.latency_ms.neo4j} ms)`,
+          `SQLite: ${db.sqlite} (${db.latency_ms.sqlite} ms)`,
+          `Version: ${info.version}`,
+          `Build: ${info.build_sha}`,
+          `Started: ${info.start_time}`
+        ];
+        document.getElementById('health').textContent = lines.join('\n');
+      } catch (err) {
+        document.getElementById('health').textContent = 'Unable to load metrics';
+      }
+    }
+    document.addEventListener('DOMContentLoaded', loadHealth);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- serve `index.html` from the root URL
- display service health metrics using `/db/health` and `/info` endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865caee72d08333ab5a3b81be12f87c