### PR TITLE
Update docs with API instructions, handle missing Neo4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![build](https://github.com/builtbycorelot/NFL/actions/workflows/ci.yml/badge.svg)
 ![coverage](https://codecov.io/gh/builtbycorelot/NFL/branch/main/graph/badge.svg)
+![compose](https://github.com/builtbycorelot/NFL/actions/workflows/test.yml/badge.svg)
 
 * Node Form Language is a metaframework to organize knowledge and action.
 * Graphs express relationships
@@ -43,6 +44,7 @@ Think of this as distilling ideas from RedNode and Neo4j into a tiny set of verb
 * [Context](docs/context.md) – repository anchor and semantic index.
 * [CodeRabbit Badge](docs/coderabbit_badge.md) – badge parameters for PR review counts.
 * [Operational Spec](docs/operations.md) – run-book and API reference.
+* [OpenAPI Spec](openapi.json) – generate interactive docs with Swagger UI.
 
 ## Development and Testing
 Install dependencies in editable mode and run the tests:
@@ -111,7 +113,10 @@ Install the package in editable mode and run the CLI:
 ```bash
 pip install -e .
 nfl-cli validate examples/simple.json
+nfl-cli examples/simple.json --export-openapi openapi.json
 ```
+
+Open `openapi.json` in [Swagger UI](https://petstore.swagger.io/) for interactive API docs.
 
 Open a browser at `http://localhost` after running `docker-compose up` to view the HTML pages served by Apache. Neo4j is available on port `7474` and PostgreSQL on `5432`.
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,18 @@
   </ul>
   <p>See the <a href="https://builtbycorelot.github.io/NFL">GitHub Pages site</a> for a hosted version.</p>
 
+  <h2>API Usage</h2>
+  <p>The HTTP API is served from the same base URL as this page. Common routes:</p>
+  <pre>
+GET /health
+GET /db/health
+POST /api/cypher
+POST /api/sql
+  </pre>
+  <p>Download the <a href="openapi.json">OpenAPI specification</a> and open it with
+    <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/builtbycorelot/NFL/main/openapi.json">Swagger UI</a>
+    for interactive documentation.</p>
+
   <h2>Service Health</h2>
   <pre id="health">Loading...</pre>
 

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,146 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "NFL Graph - NFL-Core",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/nodes": {
+      "get": {
+        "summary": "List nodes",
+        "responses": {
+          "200": {
+            "description": "List of nodes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Node"
+                  }
+                },
+                "example": [
+                  {
+                    "name": "NodeOS",
+                    "type": "system",
+                    "traits": {
+                      "doc": "base runtime"
+                    }
+                  },
+                  {
+                    "name": "NFL-Core",
+                    "type": "dialect",
+                    "traits": {
+                      "doc": "core grammar"
+                    }
+                  },
+                  {
+                    "name": "Codec.fn",
+                    "type": "function",
+                    "traits": {
+                      "doc": "graph transforms"
+                    }
+                  },
+                  {
+                    "name": "CostModel",
+                    "type": "analysis",
+                    "traits": {
+                      "doc": "resource tracking"
+                    }
+                  },
+                  {
+                    "name": "SemanticLedger",
+                    "type": "ledger",
+                    "traits": {
+                      "doc": "provenance"
+                    }
+                  },
+                  {
+                    "name": "PLight.token",
+                    "type": "hardware",
+                    "traits": {
+                      "doc": "trust anchor"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/edges": {
+      "get": {
+        "summary": "List edges",
+        "responses": {
+          "200": {
+            "description": "List of edges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Edge"
+                  }
+                },
+                "example": [
+                  {
+                    "from": "NFL-Core",
+                    "to": "NodeOS",
+                    "type": "REL1"
+                  },
+                  {
+                    "from": "Codec.fn",
+                    "to": "NFL-Core",
+                    "type": "REL1"
+                  },
+                  {
+                    "from": "CostModel",
+                    "to": "NFL-Core",
+                    "type": "REL2"
+                  },
+                  {
+                    "from": "SemanticLedger",
+                    "to": "CostModel",
+                    "type": "REL3"
+                  },
+                  {
+                    "from": "PLight.token",
+                    "to": "SemanticLedger",
+                    "type": "REL4"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Node": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "Edge": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -27,3 +27,11 @@ def test_info_endpoint():
     assert 'version' in data
     assert 'start_time' in data
 
+
+def test_cypher_disabled(monkeypatch):
+    """Cypher endpoint should return 503 when Neo4j is disabled."""
+    monkeypatch.setattr(app, 'driver', None)
+    client = flask_app.test_client()
+    resp = client.post('/api/cypher', json={'query': 'RETURN 1'})
+    assert resp.status_code == 503
+

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,8 @@
+import json
+from cli import nfl_to_openapi
+
+
+def test_openapi_paths():
+    spec = nfl_to_openapi.convert_file('index.nfl.json')
+    assert '/nodes' in spec['paths']
+    assert '/edges' in spec['paths']


### PR DESCRIPTION
## Summary
- show instructions for API usage on index.html
- generate and check in `openapi.json`
- add new Compose badge in README and instructions for using Swagger UI
- support disabled Neo4j configuration
- add tests for new behaviour and OpenAPI conversion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865ced3b1f88333bc7bb93cfcdb4e0f