### PR TITLE
Update API instructions and switch to Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ docker build -t nfl-api .
 docker run -it --rm -p 8080:8080 \
     -e PORT=8080 \
     -e NEO4J_URI=bolt://host.docker.internal:7687 \
+    -e POSTGRES_URI="dbname=nfl user=nfl password=nfl host=host.docker.internal" \
     nfl-api
 curl http://localhost:8080/health
 ```
@@ -96,7 +97,7 @@ Service type: Web Service
 Build Command: (leave blank)
 Start Command: (leave blank)
 Health Check path: /health
-Env vars: NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD
+Env vars: NEO4J_URI, NEO4J_USER, NEO4J_PASSWORD, POSTGRES_URI
 ```
 
 Render maps `$PORT` to `8080` automatically. Create a second service if you

--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
 from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
 import json
-import sqlite3
+import psycopg2
+import psycopg2.extras
 from neo4j import GraphDatabase
 import os
 from datetime import datetime
@@ -14,7 +15,7 @@ CORS(app)
 NEO4J_URI = os.getenv('NEO4J_URI')
 NEO4J_USER = os.getenv('NEO4J_USER', 'neo4j')
 NEO4J_PASSWORD = os.getenv('NEO4J_PASSWORD', 'password')
-SQLITE_DB = os.getenv('SQLITE_DB', 'nfl.db')
+POSTGRES_URI = os.getenv('POSTGRES_URI', 'dbname=nfl user=nfl password=nfl host=localhost')
 
 # Neo4j driver (optional)
 if NEO4J_URI:
@@ -35,13 +36,17 @@ VERSION = os.getenv("NFL_VERSION", "0.2.0")
 BUILD_SHA = os.getenv("BUILD_SHA", "dev")
 START_TIME = datetime.utcnow()
 
-# Initialize SQLite database
-def init_sqlite():
-    conn = sqlite3.connect(SQLITE_DB)
+# Initialize PostgreSQL database if enabled
+def init_postgres():
+    if not POSTGRES_URI:
+        return
+    try:
+        conn = psycopg2.connect(POSTGRES_URI)
+    except Exception:
+        return
     cursor = conn.cursor()
-
-    # Create tables for NFL data
-    cursor.execute('''
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS teams (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,
@@ -50,9 +55,10 @@ def init_sqlite():
             division TEXT,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
-    ''')
-
-    cursor.execute('''
+        """
+    )
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS players (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,
@@ -64,9 +70,10 @@ def init_sqlite():
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (team_id) REFERENCES teams(id)
         )
-    ''')
-
-    cursor.execute('''
+        """
+    )
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS games (
             id TEXT PRIMARY KEY,
             home_team_id TEXT,
@@ -80,13 +87,13 @@ def init_sqlite():
             FOREIGN KEY (home_team_id) REFERENCES teams(id),
             FOREIGN KEY (away_team_id) REFERENCES teams(id)
         )
-    ''')
-
+        """
+    )
     conn.commit()
     conn.close()
 
 # Initialize on startup
-init_sqlite()
+init_postgres()
 
 @app.route('/health', methods=['GET'])
 def health():
@@ -95,7 +102,7 @@ def health():
 
 @app.route('/db/health', methods=['GET'])
 def db_health():
-    """Check connectivity to Neo4j and SQLite."""
+    """Check connectivity to Neo4j and PostgreSQL."""
     status = {}
     latency = {}
 
@@ -112,18 +119,23 @@ def db_health():
     latency['neo4j'] = round((time.perf_counter() - start) * 1000, 2)
 
     start = time.perf_counter()
-    try:
-        conn = sqlite3.connect(SQLITE_DB)
-        conn.execute("SELECT 1")
-        conn.close()
-        status['sqlite'] = 'ok'
-    except Exception:
-        status['sqlite'] = 'error'
-    latency['sqlite'] = round((time.perf_counter() - start) * 1000, 2)
+    if POSTGRES_URI:
+        try:
+            conn = psycopg2.connect(POSTGRES_URI)
+            cur = conn.cursor()
+            cur.execute("SELECT 1")
+            cur.close()
+            conn.close()
+            status['postgres'] = 'ok'
+        except Exception:
+            status['postgres'] = 'error'
+    else:
+        status['postgres'] = 'disabled'
+    latency['postgres'] = round((time.perf_counter() - start) * 1000, 2)
 
     return jsonify({
         'neo4j': status['neo4j'],
-        'sqlite': status['sqlite'],
+        'postgres': status['postgres'],
         'latency_ms': latency,
     })
 
@@ -188,11 +200,11 @@ def execute_cypher():
 @app.route('/api/sql', methods=['POST'])
 def execute_sql():
     """
-    Execute SQL queries against SQLite database
+    Execute SQL queries against the PostgreSQL database
 
     Expected JSON payload:
     {
-        "query": "SELECT * FROM teams WHERE conference = ?",
+        "query": "SELECT * FROM teams WHERE conference = %s",
         "parameters": ["NFC"]
     }
     """
@@ -208,9 +220,11 @@ def execute_sql():
         if not query.strip().upper().startswith('SELECT'):
             return jsonify({'error': 'Only SELECT queries are allowed'}), 403
 
-        conn = sqlite3.connect(SQLITE_DB)
-        conn.row_factory = sqlite3.Row  # Enable column access by name
-        cursor = conn.cursor()
+        if not POSTGRES_URI:
+            return jsonify({'error': 'PostgreSQL disabled'}), 503
+
+        conn = psycopg2.connect(POSTGRES_URI)
+        cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
 
         cursor.execute(query, parameters)
         rows = cursor.fetchall()
@@ -218,6 +232,7 @@ def execute_sql():
         # Convert rows to dictionaries
         results = [dict(row) for row in rows]
 
+        cursor.close()
         conn.close()
 
         return jsonify({
@@ -246,20 +261,35 @@ def import_nfl_data():
         # Validate against NFL schema first
         # ... validation logic ...
 
-        # Import to SQLite
-        conn = sqlite3.connect(SQLITE_DB)
-        cursor = conn.cursor()
+        # Import to PostgreSQL
+        if POSTGRES_URI:
+            conn = psycopg2.connect(POSTGRES_URI)
+            cursor = conn.cursor()
 
-        # Import teams
-        for team in data.get('teams', []):
-            cursor.execute('''
-                INSERT OR REPLACE INTO teams (id, name, city, conference, division)
-                VALUES (?, ?, ?, ?, ?)
-            ''', (team['id'], team['name'], team.get('city'),
-                  team.get('conference'), team.get('division')))
+            # Import teams
+            for team in data.get('teams', []):
+                cursor.execute(
+                    """
+                    INSERT INTO teams (id, name, city, conference, division)
+                    VALUES (%s, %s, %s, %s, %s)
+                    ON CONFLICT (id) DO UPDATE SET
+                        name = EXCLUDED.name,
+                        city = EXCLUDED.city,
+                        conference = EXCLUDED.conference,
+                        division = EXCLUDED.division
+                    """,
+                    (
+                        team['id'],
+                        team['name'],
+                        team.get('city'),
+                        team.get('conference'),
+                        team.get('division'),
+                    ),
+                )
 
-        conn.commit()
-        conn.close()
+            conn.commit()
+            cursor.close()
+            conn.close()
 
         # Import to Neo4j if available
         if driver is not None:
@@ -315,12 +345,12 @@ def get_examples():
         'sql_examples': [
             {
                 'description': 'Get team standings by conference',
-                'query': 'SELECT name, city, division FROM teams WHERE conference = ? ORDER BY division, name',
+                'query': 'SELECT name, city, division FROM teams WHERE conference = %s ORDER BY division, name',
                 'parameters': ['AFC']
             },
             {
                 'description': 'Find games by score difference',
-                'query': 'SELECT * FROM games WHERE ABS(home_score - away_score) > ? ORDER BY game_date DESC',
+                'query': 'SELECT * FROM games WHERE ABS(home_score - away_score) > %s ORDER BY game_date DESC',
                 'parameters': [20]
             },
             {

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,8 @@
 # API Server
 
-The API container exposes HTTP endpoints for querying the local Neo4j and SQLite
-instances. It starts automatically when running `docker-compose up` and listens
+The API container exposes HTTP endpoints for querying the local Neo4j and
+PostgreSQL instances. It starts automatically when running `docker-compose up`
+and listens
 on port `8080`.
 
 When using `docker-compose` locally the Apache container serves this
@@ -12,9 +13,41 @@ domain instead, so `/health` is reachable at `https://your-app.onrender.com/heal
 
 - `GET /health` – simple health check returning service status.
 - `POST /api/cypher` – execute Cypher queries against Neo4j.
-- `POST /api/sql` – run read-only SQL against the bundled SQLite database.
+- `POST /api/sql` – run read-only SQL against PostgreSQL.
 - `POST /api/import` – import NFL JSON data into both databases.
 - `GET /api/examples` – sample requests for each API.
 
 All endpoints accept and return JSON. Environment variables control database
 locations and credentials when running inside Docker.
+
+## Quick Test
+
+Verify the server is reachable:
+
+```bash
+curl http://localhost:8080/health
+```
+
+The command should return `{"status":"healthy","service":"NFL Query API"}`.
+
+### Add a Node
+
+Use the Cypher endpoint to create a team node in Neo4j:
+
+```bash
+curl -X POST http://localhost:8080/api/cypher \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"CREATE (:Team {id: $id, name: $name})","parameters":{"id":"TB","name":"Tampa Bay"}}'
+```
+
+### Add a Relationship
+
+Create a relationship between teams:
+
+```bash
+curl -X POST http://localhost:8080/api/cypher \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"MATCH (a:Team {id:$a}),(b:Team {id:$b}) CREATE (a)-[:RIVAL]->(b)","parameters":{"a":"TB","b":"NO"}}'
+```
+
+These commands assume `NEO4J_URI` points at a running Neo4j instance.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -28,8 +28,8 @@ curl http://localhost:8080/health  # -> {"status":"ok"}
 | `PORT` | `8080` | Required on Render. TCP port the API binds. |
 | `WORKERS` | `2` | Gunicorn worker count. |
 | `LOG_LEVEL` | `info` | debug/info/warning/error |
-| `NEO4J_URI` | *(empty – SQLite only mode)* | Bolt URI; if unset, Neo4j routes are disabled. |
-| `SQLITE_PATH` | `data/nfl.db` | File path for local embedded SQLite. |
+| `NEO4J_URI` | *(empty – Neo4j disabled)* | Bolt URI; if unset, Neo4j routes are disabled. |
+| `POSTGRES_URI` | `dbname=nfl user=nfl password=nfl host=localhost` | Connection string for PostgreSQL. |
 
 ## API Surface
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ flask-cors
 neo4j-driver
 gunicorn
 python-dotenv
+psycopg2-binary

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "neo4j-driver",
         "gunicorn",
         "python-dotenv",
+        "psycopg2-binary",
     ],
     extras_require={
         "test": [

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -16,7 +16,7 @@ def test_db_health_endpoint():
     assert resp.status_code == 200
     data = resp.get_json()
     assert 'neo4j' in data
-    assert 'sqlite' in data
+    assert 'postgres' in data
 
 
 def test_info_endpoint():


### PR DESCRIPTION
## Summary
- connect API to PostgreSQL instead of SQLite
- add POSTGRES_URI env var and create Postgres tables on startup
- update health check, SQL execution and import endpoints for Postgres
- document example API calls for adding nodes and relationships
- mention POSTGRES_URI in README and operational docs
- adjust tests for postgres key

## Testing
- `pip install -e .[test]` *(fails: Could not install dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865d1309cd483339311a0c272c9ccfd