### PR TITLE
Improve API docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,11 @@
   <pre>
 GET /health
 GET /db/health
+GET /info
 POST /api/cypher
 POST /api/sql
+POST /api/import
+GET /api/examples
   </pre>
   <p>Download the <a href="openapi.json">OpenAPI specification</a> and open it with
     <a href="https://petstore.swagger.io/?url=https://raw.githubusercontent.com/builtbycorelot/NFL/main/openapi.json">Swagger UI</a>


### PR DESCRIPTION
## Summary
- expand public API table with more endpoints
- add examples for DB health, build info, SQL and import
- list new endpoints on the index page
- remove all references to football teams

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6865d4d19e0c8333998f71e7ea65deb5