### PR TITLE
Add root landing page

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -16,9 +16,7 @@ app = FastAPI(title="NFL API")
 
 # … remaining code …
 # serve a simple landing page linking to documentation
-# serve a simple landing page linking to documentation
 @app.get("/")
-def index() -> str:
 def index() -> str:
     """Landing page with helpful links."""
     return """

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -8,8 +8,13 @@ from fastapi import FastAPI
 from .routes import router
 
 app = FastAPI(title="NFL API")
+# api/__init__.py
+
+# … earlier code …
+
 app = FastAPI(title="NFL API")
 
+# … remaining code …
 # serve a simple landing page linking to documentation
 @app.get("/")
 @app.get("/")

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -16,8 +16,9 @@ app = FastAPI(title="NFL API")
 
 # … remaining code …
 # serve a simple landing page linking to documentation
+# serve a simple landing page linking to documentation
 @app.get("/")
-@app.get("/")
+def index() -> str:
 def index() -> str:
     """Landing page with helpful links."""
     return """

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -8,9 +8,10 @@ from fastapi import FastAPI
 from .routes import router
 
 app = FastAPI(title="NFL API")
+app = FastAPI(title="NFL API")
 
 # serve a simple landing page linking to documentation
-
+@app.get("/")
 @app.get("/")
 def index() -> str:
     """Landing page with helpful links."""

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -8,6 +8,27 @@ from fastapi import FastAPI
 from .routes import router
 
 app = FastAPI(title="NFL API")
+
+# serve a simple landing page linking to documentation
+
+@app.get("/")
+def index() -> str:
+    """Landing page with helpful links."""
+    return """
+    <html>
+      <body>
+        <h1>NFL API</h1>
+        <ul>
+          <li><a href=\"/docs\">Swagger UI</a></li>
+          <li><a href=\"/redoc\">ReDoc</a></li>
+          <li><a href=\"/openapi.json\">OpenAPI JSON</a></li>
+          <li><a href=\"/health\">Health Check</a></li>
+          <li><a href=\"https://github.com/builtbycorelot/NFL/tree/main/docs/site\">Docs Site</a></li>
+        </ul>
+      </body>
+    </html>
+    """
+
 app.include_router(router)
 
 # generate OpenAPI spec at import time

--- a/api/docs/openapi.json
+++ b/api/docs/openapi.json
@@ -1,5 +1,8 @@
 {
   "paths": {
+    "/": {
+      "get": {}
+    },
     "/health": {
       "get": {}
     },
@@ -10,19 +13,13 @@
       "get": {}
     },
     "/export/jsonld": {
-      "get": {
-        "summary": "Export graph as JSON-LD",
-        "responses": {
-          "200": {
-            "description": "JSON-LD representation",
-            "content": {
-              "application/ld+json": {
-                "schema": { "type": "object" }
-              }
-            }
-          }
-        }
-      }
+      "get": {}
+    },
+    "/export/owl": {
+      "get": {}
+    },
+    "/export/geojson": {
+      "get": {}
     },
     "/import": {
       "post": {}


### PR DESCRIPTION
## Summary
- add a new `/` route that lists helpful documentation links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68668da7ea588333ad3948edfc2717e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a landing page at the root URL ("/") with links to key resources, including documentation and health checks.
  * Added new export endpoints for OWL and GeoJSON formats.

* **Documentation**
  * Updated the API specification to reflect new and modified endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->