### PR TITLE
Ensure tests run on sample NFL file

### DIFF
--- a/nfl/parser.py
+++ b/nfl/parser.py
@@ -1,4 +1,5 @@
 """NFL parser stub using Lark."""
+
 from __future__ import annotations
 
 import re

--- a/nfl/rules.py
+++ b/nfl/rules.py
@@ -1,4 +1,5 @@
 """Minimal rule engine for NFL 'logic' trait."""
+
 from __future__ import annotations
 from typing import Any, Dict
 
@@ -16,16 +17,16 @@ def evaluate_logic(logic: Dict[str, Any] | None, scope: Dict[str, Any]) -> bool:
     """
     if not logic:
         return True
-    if 'expr' in logic:
-        return bool(eval(str(logic['expr']), {}, {'scope': scope}))
-    if 'all' in logic:
-        return all(evaluate_logic(item, scope) for item in logic['all'])
-    if 'any' in logic:
-        return any(evaluate_logic(item, scope) for item in logic['any'])
-    if 'not' in logic:
-        return not evaluate_logic(logic['not'], scope)
-    if 'equals' in logic:
-        left, right = logic['equals']
+    if "expr" in logic:
+        return bool(eval(str(logic["expr"]), {}, {"scope": scope}))
+    if "all" in logic:
+        return all(evaluate_logic(item, scope) for item in logic["all"])
+    if "any" in logic:
+        return any(evaluate_logic(item, scope) for item in logic["any"])
+    if "not" in logic:
+        return not evaluate_logic(logic["not"], scope)
+    if "equals" in logic:
+        left, right = logic["equals"]
         lv = scope.get(left, left) if isinstance(left, str) else left
         rv = scope.get(right, right) if isinstance(right, str) else right
         return lv == rv

--- a/tests/data/sample_workflow.nfl
+++ b/tests/data/sample_workflow.nfl
@@ -1,0 +1,7 @@
+// NFL v0.3
+node: sample_workflow | isa:"Workflow"
+    trait: trigger: "new_ticket"
+    edge: step -> node: first_step
+
+node: first_step | isa:"Step"
+    trait: action_py: "handlers.process"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import sys
 import pathlib
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import pytest
 from nfl import validate_graph, to_jsonld, to_owl, to_xml, to_sql

--- a/tests/test_nfl_validation.py
+++ b/tests/test_nfl_validation.py
@@ -1,12 +1,14 @@
 import sys
 import pathlib
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from nfl.parser import parse_nfl
 from jsonschema import Draft202012Validator
 import json
 
-SCHEMA = json.load(open('schema/nfl.schema.json'))
-NFL_FILES = pathlib.Path('.').glob('**/*.nfl')
+SCHEMA = json.load(open("schema/nfl.schema.json"))
+NFL_FILES = pathlib.Path(".").glob("**/*.nfl")
+
 
 def test_nfl_files():
     for path in NFL_FILES:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,5 +1,6 @@
 import sys
 import pathlib
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from nfl.rules import evaluate_logic, RuleEngine
 


### PR DESCRIPTION
## Summary
- add a sample `.nfl` workflow for validation tests
- run `black` formatting on code and tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869286237e08333b760815108ade2bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code consistency by updating quotation marks and adding blank lines for readability across multiple files.

* **Tests**
  * Introduced a new sample workflow definition for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->