### PR TITLE
Add simple NFL linter

### DIFF
--- a/lint_nfl.py
+++ b/lint_nfl.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Simple NFL linter for Node Form Language v2.0.0.
+
+This script checks an NFL file for common formatting and syntax issues
+including indentation, node and edge declarations, trait blocks and
+duplicate node identifiers. It is intentionally minimal and does not
+fully parse the language.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+NODE_RE = re.compile(r"^node:\s+(?P<id>\S+)$")
+EDGE_RE = re.compile(r"^edge:\s+(\S+)\s+->\s+(\S+)\s+->\s+(\S+)$")
+PROP_RE = re.compile(r"^\|\s+\w[\w.-]*:\s+.+$")
+TRAIT_START_RE = re.compile(r"^\|\s+trait\.\w+$")
+
+
+class NFLint:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.errors: list[str] = []
+        self.nodes: set[str] = set()
+        self.in_trait = False
+
+    def lint(self) -> None:
+        for lineno, raw in enumerate(self.path.read_text().splitlines(), 1):
+            line = raw.rstrip()
+            indent = len(line) - len(line.lstrip(" "))
+            if "\t" in line:
+                self.errors.append(f"{lineno}: tabs are not allowed")
+            if indent % 2 != 0:
+                self.errors.append(
+                    f"{lineno}: indentation must be multiples of 2 spaces"
+                )
+            stripped = line.lstrip()
+            if not stripped:
+                continue
+            if indent == 0:
+                self._check_top_level(lineno, stripped)
+            elif indent == 2:
+                self._check_prop_or_trait(lineno, stripped)
+            elif indent == 4:
+                self._check_trait_prop(lineno, stripped)
+            else:
+                self.errors.append(f"{lineno}: unexpected indentation level")
+
+    def _check_top_level(self, lineno: int, text: str) -> None:
+        self.in_trait = False
+        if text.startswith("pack:"):
+            return
+        if m := NODE_RE.match(text):
+            node_id = m.group("id")
+            if node_id in self.nodes:
+                self.errors.append(f"{lineno}: duplicate node identifier '{node_id}'")
+            else:
+                self.nodes.add(node_id)
+            return
+        if EDGE_RE.match(text):
+            return
+        self.errors.append(f"{lineno}: unknown or invalid top-level line")
+
+    def _check_prop_or_trait(self, lineno: int, text: str) -> None:
+        if TRAIT_START_RE.match(text):
+            self.in_trait = True
+            return
+        if PROP_RE.match(text):
+            return
+        self.errors.append(f"{lineno}: invalid property or trait declaration")
+
+    def _check_trait_prop(self, lineno: int, text: str) -> None:
+        if not self.in_trait:
+            self.errors.append(f"{lineno}: trait property outside of trait block")
+            return
+        if PROP_RE.match(text):
+            return
+        self.errors.append(f"{lineno}: invalid trait property line")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: lint_nfl.py <file.nfl>")
+        sys.exit(1)
+    path = Path(sys.argv[1])
+    linter = NFLint(path)
+    linter.lint()
+    if linter.errors:
+        for msg in linter.errors:
+            print(f"Error: {msg}")
+        sys.exit(1)
+    print("NFL lint passed")

--- a/nfl/parser.py
+++ b/nfl/parser.py
@@ -1,4 +1,5 @@
 """NFL parser stub using Lark."""
+
 from __future__ import annotations
 
 import re

--- a/nfl/rules.py
+++ b/nfl/rules.py
@@ -1,4 +1,5 @@
 """Minimal rule engine for NFL 'logic' trait."""
+
 from __future__ import annotations
 from typing import Any, Dict
 
@@ -16,16 +17,16 @@ def evaluate_logic(logic: Dict[str, Any] | None, scope: Dict[str, Any]) -> bool:
     """
     if not logic:
         return True
-    if 'expr' in logic:
-        return bool(eval(str(logic['expr']), {}, {'scope': scope}))
-    if 'all' in logic:
-        return all(evaluate_logic(item, scope) for item in logic['all'])
-    if 'any' in logic:
-        return any(evaluate_logic(item, scope) for item in logic['any'])
-    if 'not' in logic:
-        return not evaluate_logic(logic['not'], scope)
-    if 'equals' in logic:
-        left, right = logic['equals']
+    if "expr" in logic:
+        return bool(eval(str(logic["expr"]), {}, {"scope": scope}))
+    if "all" in logic:
+        return all(evaluate_logic(item, scope) for item in logic["all"])
+    if "any" in logic:
+        return any(evaluate_logic(item, scope) for item in logic["any"])
+    if "not" in logic:
+        return not evaluate_logic(logic["not"], scope)
+    if "equals" in logic:
+        left, right = logic["equals"]
         lv = scope.get(left, left) if isinstance(left, str) else left
         rv = scope.get(right, right) if isinstance(right, str) else right
         return lv == rv

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import sys
 import pathlib
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import pytest
 from nfl import validate_graph, to_jsonld, to_owl, to_xml, to_sql

--- a/tests/test_nfl_validation.py
+++ b/tests/test_nfl_validation.py
@@ -1,12 +1,14 @@
 import sys
 import pathlib
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from nfl.parser import parse_nfl
 from jsonschema import Draft202012Validator
 import json
 
-SCHEMA = json.load(open('schema/nfl.schema.json'))
-NFL_FILES = pathlib.Path('.').glob('**/*.nfl')
+SCHEMA = json.load(open("schema/nfl.schema.json"))
+NFL_FILES = pathlib.Path(".").glob("**/*.nfl")
+
 
 def test_nfl_files():
     for path in NFL_FILES:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,5 +1,6 @@
 import sys
 import pathlib
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from nfl.rules import evaluate_logic, RuleEngine
 


### PR DESCRIPTION
## Summary
- add standalone `lint_nfl.py` script to lint NFL files
- run `black` on repo (autoformatted existing modules and tests)

## Testing
- `ruff check .`
- `black .`
- `pytest -q`
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869586325a88333bf301f87e8ca2ceb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line tool for basic linting of Node Form Language (NFL) files, providing clear error messages for formatting and syntax issues.

* **Style**
  * Standardized string literals to use double quotes in certain files.
  * Improved code readability by adding blank lines in various files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->